### PR TITLE
adding option to baphy_load_recording to use rawids

### DIFF
--- a/nems_db/baphy.py
+++ b/nems_db/baphy.py
@@ -569,6 +569,7 @@ def baphy_load_data(parmfilepath, options={}):
             stim_object = 'ReferenceHandle'
 
         tags = exptparams['TrialObject'][1][stim_object][1]['Names']
+        tags, tagids = np.unique(tags, return_index=True)
         stimparam = []
 
     # figure out spike file to load
@@ -1301,11 +1302,23 @@ def baphy_load_recording_nonrasterized(cellid, batch, options):
 
 
 def baphy_data_path(options):
-
+    """
+    TODO: include options['site'] for multichannel recordings
+    """
+    if (type(options['cellid'])==list) & (len(options["cellid"])>1):
+        cellid=options['cellid'][0]
+        siteid=cellid.split("-")[0]
+    elif (type(options['cellid'])==list):
+        cellid=options['cellid'][0]
+        siteid=cellid
+    else:
+        cellid=options['cellid']
+        siteid=cellid
+        
     data_path = ("/auto/data/nems_db/recordings/{0}/{1}{2}_fs{3}/"
                  .format(options["batch"], options['stimfmt'],
                          options["chancount"], options["rasterfs"]))
-    data_file = data_path + options["cellid"] + '.tgz'
+    data_file = data_path + siteid + '.tgz'
 
     log.info(data_file)
     log.info(options)
@@ -1315,7 +1328,7 @@ def baphy_data_path(options):
         #          options['cellid'], options['batch'], options
         #          )
         rec = baphy_load_recording_nonrasterized(
-                options['cellid'], options['batch'], options
+                cellid, options['batch'], options
                 )
         rec.save(data_file)
 

--- a/nems_db/baphy.py
+++ b/nems_db/baphy.py
@@ -1037,8 +1037,12 @@ def baphy_load_recording(cellid, batch, options):
     options['runclass'] = options.get('runclass', None)
     options['cellid'] = options.get('cellid', cellid)
     options['batch'] = int(batch)
-
-    d = db.get_batch_cell_data(batch=batch, cellid=cellid, label='parm')
+    options['rawid'] = options.get('rawid', None)    
+    
+    d = db.get_batch_cell_data(batch=batch, 
+                               cellid=cellid, 
+                               rawid = options['rawid'], 
+                               label='parm')
     if len(d)==0:
         raise ValueError('cellid/batch entry not found in NarfData')
 

--- a/nems_db/db.py
+++ b/nems_db/db.py
@@ -591,7 +591,8 @@ def get_batch_cell_data(batch=None, cellid=None, rawid=None, label=None
        params = params+(cellid+"%",)
 
     if not rawid is None:
-       sql += " AND rawid=%s"
+       sql += " AND rawid IN %s"
+       rawid = tuple([str(i) for i in list(rawid)])
        params = params+(rawid,)
 
     if not label is None:


### PR DESCRIPTION
This is useful for array recording when you try to load multiple files that have been sorted independently and don't have the same units across all of them. Right now, baphy_load_recording can't handle that situation (can't concatenate signals (resp) in time that have diff numbers of channels (units)). TODO. This is just a bandaid that let's you specify that you only want to load parmfiles for rawids where the units are stable across all files.