### PR TITLE
Add manager to facilitate loading of experiments and align data using OpenEphys timestamps

### DIFF
--- a/nems_lbhb/OpenEphys.py
+++ b/nems_lbhb/OpenEphys.py
@@ -1,0 +1,467 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Sun Aug  3 15:18:38 2014
+
+@author: Dan Denman and Josh Siegle
+
+Loads .continuous, .events, and .spikes files saved from the Open Ephys GUI
+
+Usage:
+    import OpenEphys
+    data = OpenEphys.load(pathToFile) # returns a dict with data, timestamps, etc.
+
+"""
+
+import os
+import numpy as np
+import scipy.signal
+import scipy.io
+import time
+import struct
+from copy import deepcopy
+
+# constants
+NUM_HEADER_BYTES = 1024
+SAMPLES_PER_RECORD = 1024
+BYTES_PER_SAMPLE = 2
+RECORD_SIZE = 4 + 8 + SAMPLES_PER_RECORD * BYTES_PER_SAMPLE + 10 # size of each continuous record in bytes
+RECORD_MARKER = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 255])
+
+# constants for pre-allocating matrices:
+MAX_NUMBER_OF_SPIKES = int(1e6)
+MAX_NUMBER_OF_RECORDS = int(1e6)
+MAX_NUMBER_OF_EVENTS = int(1e6)
+
+def load(filepath):
+
+    # redirects to code for individual file types
+    if 'continuous' in filepath:
+        data = loadContinuous(filepath)
+    elif 'spikes' in filepath:
+        data = loadSpikes(filepath)
+    elif 'events' in filepath:
+        data = loadEvents(filepath)
+    else:
+        raise Exception("Not a recognized file type. Please input a .continuous, .spikes, or .events file")
+
+    return data
+
+def loadFolder(folderpath, dtype = float, **kwargs):
+
+    # load all continuous files in a folder
+
+    data = { }
+
+    # load all continuous files in a folder
+    if 'channels' in kwargs.keys():
+        filelist = ['100_CH'+x+'.continuous' for x in map(str,kwargs['channels'])]
+    else:
+        filelist = os.listdir(folderpath)
+
+    t0 = time.time()
+    numFiles = 0
+
+    for i, f in enumerate(filelist):
+        if '.continuous' in f:
+            data[f.replace('.continuous','')] = loadContinuous(os.path.join(folderpath, f), dtype = dtype)
+            numFiles += 1
+
+    print(''.join(('Avg. Load Time: ', str((time.time() - t0)/numFiles),' sec')))
+    print(''.join(('Total Load Time: ', str((time.time() - t0)),' sec')))
+
+    return data
+
+def loadFolderToArray(folderpath, channels = 'all', chprefix = 'CH', 
+                      dtype = float, session = '0', source = '100'):
+    '''Load continuous files in specified folder to a single numpy array. By default all
+    CH continous files are loaded in numerical order, ordering can be specified with
+    optional channels argument which should be a list of channel numbers.'''
+    
+    if channels == 'all':
+        channels = _get_sorted_channels(folderpath, chprefix, session, source)
+    
+    if session == '0':
+        filelist = [source + '_'+chprefix + x + '.continuous' for x in map(str,channels)]
+    else:
+        filelist = [source + '_'+chprefix + x + '_' + session + '.continuous' for x in map(str,channels)]
+    
+    t0 = time.time()
+    numFiles = 1
+
+    channel_1_data = loadContinuous(os.path.join(folderpath, filelist[0]), dtype)['data']
+
+    n_samples  = len(channel_1_data)
+    n_channels = len(filelist)
+
+    data_array = np.zeros([n_samples, n_channels], dtype)
+    data_array[:,0] = channel_1_data
+
+    for i, f in enumerate(filelist[1:]):
+            data_array[:, i + 1] = loadContinuous(os.path.join(folderpath, f), dtype)['data']
+            numFiles += 1
+
+    print(''.join(('Avg. Load Time: ', str((time.time() - t0)/numFiles),' sec')))
+    print(''.join(('Total Load Time: ', str((time.time() - t0)),' sec')))
+
+    return data_array
+
+def loadContinuous(filepath, dtype = float):
+
+    assert dtype in (float, np.int16), \
+      'Invalid data type specified for loadContinous, valid types are float and np.int16'
+
+    print("Loading continuous data...")
+
+    ch = { }
+
+    #read in the data
+    f = open(filepath,'rb')
+
+    fileLength = os.fstat(f.fileno()).st_size
+
+    # calculate number of samples
+    recordBytes = fileLength - NUM_HEADER_BYTES
+    if  recordBytes % RECORD_SIZE != 0:
+        raise Exception("File size is not consistent with a continuous file: may be corrupt")
+    nrec = recordBytes // RECORD_SIZE
+    nsamp = nrec * SAMPLES_PER_RECORD
+    # pre-allocate samples
+    samples = np.zeros(nsamp, dtype)
+    timestamps = np.zeros(nrec)
+    recordingNumbers = np.zeros(nrec)
+    indices = np.arange(0, nsamp + 1, SAMPLES_PER_RECORD, np.dtype(np.int64))
+
+    header = readHeader(f)
+
+    recIndices = np.arange(0, nrec)
+
+    for recordNumber in recIndices:
+
+        timestamps[recordNumber] = np.fromfile(f,np.dtype('<i8'),1) # little-endian 64-bit signed integer
+        N = np.fromfile(f,np.dtype('<u2'),1)[0] # little-endian 16-bit unsigned integer
+
+        #print index
+
+        if N != SAMPLES_PER_RECORD:
+            raise Exception('Found corrupted record in block ' + str(recordNumber))
+
+        recordingNumbers[recordNumber] = (np.fromfile(f,np.dtype('>u2'),1)) # big-endian 16-bit unsigned integer
+
+        if dtype == float: # Convert data to float array and convert bits to voltage.
+            data = np.fromfile(f,np.dtype('>i2'),N) * float(header['bitVolts']) # big-endian 16-bit signed integer, multiplied by bitVolts
+        else:  # Keep data in signed 16 bit integer format.
+            data = np.fromfile(f,np.dtype('>i2'),N)  # big-endian 16-bit signed integer
+        samples[indices[recordNumber]:indices[recordNumber+1]] = data
+
+        marker = f.read(10) # dump
+
+    #print recordNumber
+    #print index
+
+    ch['header'] = header
+    ch['timestamps'] = timestamps
+    ch['data'] = samples  # OR use downsample(samples,1), to save space
+    ch['recordingNumber'] = recordingNumbers
+    f.close()
+    return ch
+
+def loadSpikes(filepath):
+
+    '''
+    Loads spike waveforms and timestamps from filepath (should be .spikes file)
+
+    '''
+
+    data = { }
+
+    print('loading spikes...')
+
+    f = open(filepath, 'rb')
+    header = readHeader(f)
+
+    if float(header[' version']) < 0.4:
+        raise Exception('Loader is only compatible with .spikes files with version 0.4 or higher')
+
+    data['header'] = header
+    numChannels = int(header['num_channels'])
+    numSamples = 40 # **NOT CURRENTLY WRITTEN TO HEADER**
+
+    spikes = np.zeros((MAX_NUMBER_OF_SPIKES, numSamples, numChannels))
+    timestamps = np.zeros(MAX_NUMBER_OF_SPIKES)
+    source = np.zeros(MAX_NUMBER_OF_SPIKES)
+    gain = np.zeros((MAX_NUMBER_OF_SPIKES, numChannels))
+    thresh = np.zeros((MAX_NUMBER_OF_SPIKES, numChannels))
+    sortedId = np.zeros((MAX_NUMBER_OF_SPIKES, numChannels))
+    recNum = np.zeros(MAX_NUMBER_OF_SPIKES)
+
+    currentSpike = 0
+
+    while f.tell() < os.fstat(f.fileno()).st_size:
+        eventType = np.fromfile(f, np.dtype('<u1'),1) #always equal to 4, discard
+        timestamps[currentSpike] = np.fromfile(f, np.dtype('<i8'), 1)
+        software_timestamp = np.fromfile(f, np.dtype('<i8'), 1)
+        source[currentSpike] = np.fromfile(f, np.dtype('<u2'), 1)
+        numChannels = np.fromfile(f, np.dtype('<u2'), 1)[0]
+        numSamples = np.fromfile(f, np.dtype('<u2'), 1)[0]
+        sortedId[currentSpike] = np.fromfile(f, np.dtype('<u2'),1)
+        electrodeId = np.fromfile(f, np.dtype('<u2'),1)
+        channel = np.fromfile(f, np.dtype('<u2'),1)
+        color = np.fromfile(f, np.dtype('<u1'), 3)
+        pcProj = np.fromfile(f, np.float32, 2)
+        sampleFreq = np.fromfile(f, np.dtype('<u2'),1)
+
+        waveforms = np.fromfile(f, np.dtype('<u2'), numChannels*numSamples)
+        gain[currentSpike,:] = np.fromfile(f, np.float32, numChannels)
+        thresh[currentSpike,:] = np.fromfile(f, np.dtype('<u2'), numChannels)
+        recNum[currentSpike] = np.fromfile(f, np.dtype('<u2'), 1)
+
+        waveforms_reshaped = np.reshape(waveforms, (numChannels, numSamples))
+        waveforms_reshaped = waveforms_reshaped.astype(float)
+        waveforms_uv = waveforms_reshaped
+
+        for ch in range(numChannels):
+            waveforms_uv[ch, :] -= 32768
+            waveforms_uv[ch, :] /= gain[currentSpike, ch]*1000
+
+        spikes[currentSpike] = waveforms_uv.T
+
+        currentSpike += 1
+
+    data['spikes'] = spikes[:currentSpike,:,:]
+    data['timestamps'] = timestamps[:currentSpike]
+    data['source'] = source[:currentSpike]
+    data['gain'] = gain[:currentSpike,:]
+    data['thresh'] = thresh[:currentSpike,:]
+    data['recordingNumber'] = recNum[:currentSpike]
+    data['sortedId'] = sortedId[:currentSpike]
+
+    return data
+
+
+def loadEvents(filepath):
+
+    data = { }
+
+    print('loading events...')
+
+    f = open(filepath,'rb')
+    header = readHeader(f)
+
+    if float(header[' version']) < 0.4:
+        raise Exception('Loader is only compatible with .events files with version 0.4 or higher')
+
+    data['header'] = header
+
+    index = -1
+
+    channel = np.zeros(MAX_NUMBER_OF_EVENTS)
+    timestamps = np.zeros(MAX_NUMBER_OF_EVENTS)
+    sampleNum = np.zeros(MAX_NUMBER_OF_EVENTS)
+    nodeId = np.zeros(MAX_NUMBER_OF_EVENTS)
+    eventType = np.zeros(MAX_NUMBER_OF_EVENTS)
+    eventId = np.zeros(MAX_NUMBER_OF_EVENTS)
+    recordingNumber = np.zeros(MAX_NUMBER_OF_EVENTS)
+
+    while f.tell() < os.fstat(f.fileno()).st_size:
+
+        index += 1
+
+        timestamps[index] = np.fromfile(f, np.dtype('<i8'), 1)
+        sampleNum[index] = np.fromfile(f, np.dtype('<i2'), 1)
+        eventType[index] = np.fromfile(f, np.dtype('<u1'), 1)
+        nodeId[index] = np.fromfile(f, np.dtype('<u1'), 1)
+        eventId[index] = np.fromfile(f, np.dtype('<u1'), 1)
+        channel[index] = np.fromfile(f, np.dtype('<u1'), 1)
+        recordingNumber[index] = np.fromfile(f, np.dtype('<u2'), 1)
+
+    data['channel'] = channel[:index]
+    data['timestamps'] = timestamps[:index]
+    data['eventType'] = eventType[:index]
+    data['nodeId'] = nodeId[:index]
+    data['eventId'] = eventId[:index]
+    data['recordingNumber'] = recordingNumber[:index]
+    data['sampleNum'] = sampleNum[:index]
+
+    return data
+
+def readHeader(f):
+    header = { }
+    h = f.read(1024).decode().replace('\n','').replace('header.','')
+    for i,item in enumerate(h.split(';')):
+        if '=' in item:
+            header[item.split(' = ')[0]] = item.split(' = ')[1]
+    return header
+
+def downsample(trace,down):
+    downsampled = scipy.signal.resample(trace,np.shape(trace)[0]/down)
+    return downsampled
+
+def pack(folderpath,source='100',**kwargs):
+#convert single channel open ephys channels to a .dat file for compatibility with the KlustaSuite, Neuroscope and Klusters
+#should not be necessary for versions of open ephys which write data into HDF5 format.
+#loads .continuous files in the specified folder and saves a .DAT in that folder
+#optional arguments:
+#   source: string name of the source that openephys uses as the prefix. is usually 100, if the headstage is the first source added, but can specify something different
+#
+#   data: pre-loaded data to be packed into a .DAT
+#   dref: int specifying a channel # to use as a digital reference. is subtracted from all channels.
+#   order: the order in which the .continuos files are packed into the .DAT. should be a list of .continious channel numbers. length must equal total channels.
+#   suffix: appended to .DAT filename, which is openephys.DAT if no suffix provided.
+
+    #load the openephys data into memory
+    if 'data' not in kwargs.keys():
+        if 'channels' not in kwargs.keys():
+            data = loadFolder(folderpath, dtype = np.int16)
+        else:
+            data = loadFolder(folderpath, dtype = np.int16, channels=kwargs['channels'])
+    else:
+        data = kwargs['data']
+    #if specified, do the digital referencing
+    if 'dref' in kwargs.keys():
+        ref =load(os.path.join(folderpath,''.join((source,'_CH',str(kwargs['dref']),'.continuous'))))
+        for i,channel in enumerate(data.keys()):
+            data[channel]['data'] = data[channel]['data'] - ref['data']
+    #specify the order the channels are written in
+    if 'order' in kwargs.keys():
+        order = kwargs['order']
+    else:
+        order = list(data)
+    #add a suffix, if one was specified
+    if 'suffix' in kwargs.keys():
+        suffix=kwargs['suffix']
+    else:
+        suffix=''
+
+    #make a file to write the data back out into .dat format
+    outpath = os.path.join(folderpath,''.join(('openephys',suffix,'.dat')))
+    out = open(outpath,'wb')
+
+    #go through the data and write it out in the .dat format
+    #.dat format specified here: http://neuroscope.sourceforge.net/UserManual/data-files.html
+    channelOrder = []
+    print(''.join(('...saving .dat to ',outpath,'...')))
+    random_datakey = next(iter(data))
+    bar = ProgressBar(len(data[random_datakey]['data']))
+    for i in range(len(data[random_datakey]['data'])):
+        for j in range(len(order)):
+            if source in random_datakey:
+                ch = data[order[j]]['data']
+            else:
+                ch = data[''.join(('CH',str(order[j]).replace('CH','')))]['data']
+            out.write(struct.pack('h',ch[i]))#signed 16-bit integer
+            #figure out which order this thing packed the channels in. only do this once.
+            if i == 0:
+                channelOrder.append(order[j])
+        #update how mucb we have list
+        if i%(len(data[random_datakey]['data'])/100)==0:
+            bar.animate(i)
+    out.close()
+    print(''.join(('order: ',str(channelOrder))))
+    print(''.join(('.dat saved to ',outpath)))
+
+#**********************************************************
+# progress bar class used to show progress of pack()
+    #stolen from some post on stack overflow
+import sys
+try:
+    from IPython.display import clear_output
+    have_ipython = True
+except ImportError:
+    have_ipython = False
+class ProgressBar:
+    def __init__(self, iterations):
+        self.iterations = iterations
+        self.prog_bar = '[]'
+        self.fill_char = '*'
+        self.width = 40
+        self.__update_amount(0)
+        if have_ipython:
+            self.animate = self.animate_ipython
+        else:
+            self.animate = self.animate_noipython
+
+    def animate_ipython(self, iter):
+        print('\r', self,)
+        sys.stdout.flush()
+        self.update_iteration(iter + 1)
+
+    def update_iteration(self, elapsed_iter):
+        self.__update_amount((elapsed_iter / float(self.iterations)) * 100.0)
+        self.prog_bar += '  %d of %s complete' % (elapsed_iter, self.iterations)
+
+    def __update_amount(self, new_amount):
+        percent_done = int(round((new_amount / 100.0) * 100.0))
+        all_full = self.width - 2
+        num_hashes = int(round((percent_done / 100.0) * all_full))
+        self.prog_bar = '[' + self.fill_char * num_hashes + ' ' * (all_full - num_hashes) + ']'
+        pct_place = (len(self.prog_bar) // 2) - len(str(percent_done))
+        pct_string = '%d%%' % percent_done
+        self.prog_bar = self.prog_bar[0:pct_place] + \
+            (pct_string + self.prog_bar[pct_place + len(pct_string):])
+
+    def __str__(self):
+        return str(self.prog_bar)
+#*************************************************************
+
+def pack_2(folderpath, filename = '', channels = 'all', chprefix = 'CH', 
+           dref = None, session = '0', source = '100'):
+
+    '''Alternative version of pack which uses numpy's tofile function to write data.
+    pack_2 is much faster than pack and avoids quantization noise incurred in pack due
+    to conversion of data to float voltages during loadContinous followed by rounding
+    back to integers for packing.
+    
+    filename: Name of the output file. By default, it follows the same layout of continuous files,
+              but without the channel number, for example, '100_CHs_3.dat' or '100_ADCs.dat'.
+    
+    channels:  List of channel numbers specifying order in which channels are packed. By default
+               all CH continous files are packed in numerical order.
+    
+    chprefix:  String name that defines if channels from headstage, auxiliary or ADC inputs
+               will be loaded.
+
+    dref:  Digital referencing - either supply a channel number or 'ave' to reference to the
+           average of packed channels.
+    
+    source: String name of the source that openephys uses as the prefix. It is usually 100,
+            if the headstage is the first source added, but can specify something different.
+    
+    '''
+    
+    data_array = loadFolderToArray(folderpath, channels, chprefix, np.int16, session, source)
+    
+    if dref:
+        if dref == 'ave':
+            print('Digital referencing to average of all channels.')
+            reference = np.mean(data_array,1)
+        else:
+            print('Digital referencing to channel ' + str(dref))
+            if channels == 'all':
+                channels = _get_sorted_channels(folderpath, chprefix, session, source)
+            reference = deepcopy(data_array[:,channels.index(dref)])
+        for i in range(data_array.shape[1]):
+            data_array[:,i] = data_array[:,i] - reference
+    
+    if session == '0': session = ''
+    else: session = '_'+session
+    
+    if not filename: filename = source + '_' + chprefix + 's' + session + '.dat'
+    print('Packing data to file: ' + filename)
+    data_array.tofile(os.path.join(folderpath,filename))
+
+
+def _get_sorted_channels(folderpath, chprefix='CH', session='0', source='100'):
+    Files = [f for f in os.listdir(folderpath) if '.continuous' in f 
+                                               and '_'+chprefix in f 
+                                               and source in f]
+    
+    if session == '0':
+        Files = [f for f in Files if len(f.split('_')) == 2]
+        Chs = sorted([int(f.split('_'+chprefix)[1].split('.')[0]) for f in Files])
+    else:
+        Files = [f for f in Files if len(f.split('_')) == 3 
+                                  and f.split('.')[0].split('_')[2] == session]
+    
+        Chs = sorted([int(f.split('_'+chprefix)[1].split('_')[0]) for f in Files])
+
+    return(Chs)

--- a/nems_lbhb/OpenEphys.py
+++ b/nems_lbhb/OpenEphys.py
@@ -66,25 +66,22 @@ def loadFolder(folderpath, dtype = float, **kwargs):
             data[f.replace('.continuous','')] = loadContinuous(os.path.join(folderpath, f), dtype = dtype)
             numFiles += 1
 
-    print(''.join(('Avg. Load Time: ', str((time.time() - t0)/numFiles),' sec')))
-    print(''.join(('Total Load Time: ', str((time.time() - t0)),' sec')))
-
     return data
 
-def loadFolderToArray(folderpath, channels = 'all', chprefix = 'CH', 
+def loadFolderToArray(folderpath, channels = 'all', chprefix = 'CH',
                       dtype = float, session = '0', source = '100'):
     '''Load continuous files in specified folder to a single numpy array. By default all
     CH continous files are loaded in numerical order, ordering can be specified with
     optional channels argument which should be a list of channel numbers.'''
-    
+
     if channels == 'all':
         channels = _get_sorted_channels(folderpath, chprefix, session, source)
-    
+
     if session == '0':
         filelist = [source + '_'+chprefix + x + '.continuous' for x in map(str,channels)]
     else:
         filelist = [source + '_'+chprefix + x + '_' + session + '.continuous' for x in map(str,channels)]
-    
+
     t0 = time.time()
     numFiles = 1
 
@@ -100,8 +97,6 @@ def loadFolderToArray(folderpath, channels = 'all', chprefix = 'CH',
             data_array[:, i + 1] = loadContinuous(os.path.join(folderpath, f), dtype)['data']
             numFiles += 1
 
-    print(''.join(('Avg. Load Time: ', str((time.time() - t0)/numFiles),' sec')))
-    print(''.join(('Total Load Time: ', str((time.time() - t0)),' sec')))
 
     return data_array
 
@@ -110,7 +105,6 @@ def loadContinuous(filepath, dtype = float):
     assert dtype in (float, np.int16), \
       'Invalid data type specified for loadContinous, valid types are float and np.int16'
 
-    print("Loading continuous data...")
 
     ch = { }
 
@@ -140,8 +134,6 @@ def loadContinuous(filepath, dtype = float):
         timestamps[recordNumber] = np.fromfile(f,np.dtype('<i8'),1) # little-endian 64-bit signed integer
         N = np.fromfile(f,np.dtype('<u2'),1)[0] # little-endian 16-bit unsigned integer
 
-        #print index
-
         if N != SAMPLES_PER_RECORD:
             raise Exception('Found corrupted record in block ' + str(recordNumber))
 
@@ -155,8 +147,6 @@ def loadContinuous(filepath, dtype = float):
 
         marker = f.read(10) # dump
 
-    #print recordNumber
-    #print index
 
     ch['header'] = header
     ch['timestamps'] = timestamps
@@ -174,7 +164,6 @@ def loadSpikes(filepath):
 
     data = { }
 
-    print('loading spikes...')
 
     f = open(filepath, 'rb')
     header = readHeader(f)
@@ -242,7 +231,6 @@ def loadEvents(filepath):
 
     data = { }
 
-    print('loading events...')
 
     f = open(filepath,'rb')
     header = readHeader(f)
@@ -339,7 +327,6 @@ def pack(folderpath,source='100',**kwargs):
     #go through the data and write it out in the .dat format
     #.dat format specified here: http://neuroscope.sourceforge.net/UserManual/data-files.html
     channelOrder = []
-    print(''.join(('...saving .dat to ',outpath,'...')))
     random_datakey = next(iter(data))
     bar = ProgressBar(len(data[random_datakey]['data']))
     for i in range(len(data[random_datakey]['data'])):
@@ -356,8 +343,6 @@ def pack(folderpath,source='100',**kwargs):
         if i%(len(data[random_datakey]['data'])/100)==0:
             bar.animate(i)
     out.close()
-    print(''.join(('order: ',str(channelOrder))))
-    print(''.join(('.dat saved to ',outpath)))
 
 #**********************************************************
 # progress bar class used to show progress of pack()
@@ -403,33 +388,33 @@ class ProgressBar:
         return str(self.prog_bar)
 #*************************************************************
 
-def pack_2(folderpath, filename = '', channels = 'all', chprefix = 'CH', 
+def pack_2(folderpath, filename = '', channels = 'all', chprefix = 'CH',
            dref = None, session = '0', source = '100'):
 
     '''Alternative version of pack which uses numpy's tofile function to write data.
     pack_2 is much faster than pack and avoids quantization noise incurred in pack due
     to conversion of data to float voltages during loadContinous followed by rounding
     back to integers for packing.
-    
+
     filename: Name of the output file. By default, it follows the same layout of continuous files,
               but without the channel number, for example, '100_CHs_3.dat' or '100_ADCs.dat'.
-    
+
     channels:  List of channel numbers specifying order in which channels are packed. By default
                all CH continous files are packed in numerical order.
-    
+
     chprefix:  String name that defines if channels from headstage, auxiliary or ADC inputs
                will be loaded.
 
     dref:  Digital referencing - either supply a channel number or 'ave' to reference to the
            average of packed channels.
-    
+
     source: String name of the source that openephys uses as the prefix. It is usually 100,
             if the headstage is the first source added, but can specify something different.
-    
+
     '''
-    
+
     data_array = loadFolderToArray(folderpath, channels, chprefix, np.int16, session, source)
-    
+
     if dref:
         if dref == 'ave':
             print('Digital referencing to average of all channels.')
@@ -441,27 +426,27 @@ def pack_2(folderpath, filename = '', channels = 'all', chprefix = 'CH',
             reference = deepcopy(data_array[:,channels.index(dref)])
         for i in range(data_array.shape[1]):
             data_array[:,i] = data_array[:,i] - reference
-    
+
     if session == '0': session = ''
     else: session = '_'+session
-    
+
     if not filename: filename = source + '_' + chprefix + 's' + session + '.dat'
     print('Packing data to file: ' + filename)
     data_array.tofile(os.path.join(folderpath,filename))
 
 
 def _get_sorted_channels(folderpath, chprefix='CH', session='0', source='100'):
-    Files = [f for f in os.listdir(folderpath) if '.continuous' in f 
-                                               and '_'+chprefix in f 
+    Files = [f for f in os.listdir(folderpath) if '.continuous' in f
+                                               and '_'+chprefix in f
                                                and source in f]
-    
+
     if session == '0':
         Files = [f for f in Files if len(f.split('_')) == 2]
         Chs = sorted([int(f.split('_'+chprefix)[1].split('.')[0]) for f in Files])
     else:
-        Files = [f for f in Files if len(f.split('_')) == 3 
+        Files = [f for f in Files if len(f.split('_')) == 3
                                   and f.split('.')[0].split('_')[2] == session]
-    
+
         Chs = sorted([int(f.split('_'+chprefix)[1].split('_')[0]) for f in Files])
 
     return(Chs)

--- a/nems_lbhb/io.py
+++ b/nems_lbhb/io.py
@@ -106,6 +106,12 @@ class BAPHYExperiment:
 
     @property
     @lru_cache(maxsize=128)
+    def openephys_tarfile(self):
+        path = self.folder / 'raw' / self.experiment
+        return path.with_suffix('.tgz')
+
+    @property
+    @lru_cache(maxsize=128)
     def pupilfile(self):
         return self.parmfile.with_suffix('.pup.mat')
 


### PR DESCRIPTION
This pull request includes the following:

- Add OpenEphys reader (from OpenEphys repo)
- Allow aligning BAPHY trial information using OpenEphys timestamps rather than the spike times file
- Add BAPHYExpermeint to facilitate managing filenames and all data associated with an experiment
