### PR TITLE
return cellids_to_extract from baphy uri loading function. These then…

### DIFF
--- a/nems_lbhb/baphy.py
+++ b/nems_lbhb/baphy.py
@@ -72,9 +72,9 @@ def baphy_load_recording_file(**options):
     model fit use case options includes
     :return:
     """
-    uri = baphy_load_recording_uri(**options)
+    uri, cells_to_extract = baphy_load_recording_uri(**options)
 
-    return load_recording(uri)
+    return load_recording(uri, resp_chans=cells_to_extract)
 
 def baphy_load_recording_uri(recache=False, **options):
     """
@@ -115,7 +115,7 @@ def baphy_load_recording_uri(recache=False, **options):
 
     # parse cellid. Update cellid, siteid, rawid in options dictionary
     # if cellid/batch not specified, find them based on mfile.
-    _, options = parse_cellid(options)
+    cells_to_extract, options = parse_cellid(options)
     siteid = options['siteid']
 
     # fill in remaining default options
@@ -143,7 +143,7 @@ def baphy_load_recording_uri(recache=False, **options):
     else:
         log.info('Cached recording found: %s', data_uri)
 
-    return data_uri
+    return data_uri, cells_to_extract
 
 
 # ============================ baphy loading "utils" ==================================


### PR DESCRIPTION
return `cellids_to_extract` from `baphy_load_recording_uri`. That way, when you load the cached recording it's easy to extract the channel ids that were specified in the loading options. e.g. `siteid='DRX006b.e1:64'`