### PR TITLE
Loader keyword fix

### DIFF
--- a/nems_lbhb/baphy.py
+++ b/nems_lbhb/baphy.py
@@ -1137,7 +1137,7 @@ def baphy_load_recording(**options):
             # generate pupil signals
             t_fm = nems.signal.RasterizedSignal(
                     fs=options['rasterfs'], data=state_dict['facemap'],
-                    name='facemap', recording=rec_name, chans=[str(n) for n in range(state_dict['facemap'].shape[0])],
+                    name='facemap', recording=rec_name, chans=[f'motSVD{n}' for n in range(state_dict['facemap'].shape[0])],
                     epochs=event_times)
 
             if i == 0:

--- a/nems_lbhb/baphy.py
+++ b/nems_lbhb/baphy.py
@@ -644,7 +644,7 @@ def baphy_load_dataset(parmfilepath, **options):
                 exptevents.loc[i + 1, 'start'] = trialstoptime
                 exptevents.loc[i + 1, 'end'] = trialstoptime
 
-        print("Keeping {0}/{1} events that precede responses"
+        log.info("Keeping {0}/{1} events that precede responses"
               .format(np.sum(keepevents), len(keepevents)))
         exptevents = exptevents[keepevents].reset_index()
 

--- a/nems_lbhb/plugins/lbhb_loaders.py
+++ b/nems_lbhb/plugins/lbhb_loaders.py
@@ -16,42 +16,19 @@ def _load_dict(loadkey, cellid=None, batch=None):
         d['batch'] = batch
     return d
 
-def env(loadkey, cellid=None, batch=None):
-    """
-    envelope loader
-       extra parameters handled by loadkey parser in baphy_load_wrapper
-    """
-
-    d = _load_dict(loadkey, cellid, batch)
-    xfspec = [['nems_lbhb.xform_wrappers.baphy_load_wrapper', d]]
-    return xfspec
-
-
-def psth(loadkey, cellid=None, batch=None):
-    """
-    psth loader (no stim)
-       extra parameters handled by loadkey parser in baphy_load_wrapper
-    """
-    d = _load_dict(loadkey, cellid, batch)
-    xfspec = [['nems_lbhb.xform_wrappers.baphy_load_wrapper', d]]
-    return xfspec
-
-
-def ozgf(loadkey, cellid=None, batch=None, siteid=None, **options):
-    """
-    gammatone filter
-       extra parameters handled by loadkey parser in baphy_load_wrapper
-    """
+def _parse_baphy_loadkey(loadkey, cellid=None, batch=None, siteid=None, **options):
 
     from nems_lbhb.xform_wrappers import generate_recording_uri
     import nems_lbhb.baphy as nb
 
     pc_idx = None
+
     if type(cellid) is str:
         cc = cellid.split("_")
         if (len(cc) > 1) and (cc[1][0] == "P"):
             pc_idx = [int(cc[1][1:])]
             cellid = cc[0]
+
         elif (len(cellid.split('+')) > 1):
             # list of cellids (specified in model queue by separating with '_')
             cellid = cellid.split('+')
@@ -70,13 +47,45 @@ def ozgf(loadkey, cellid=None, batch=None, siteid=None, **options):
     if pc_idx is not None:
         context['pc_idx'] = pc_idx
 
-    xfspec = [['nems.xforms.init_context', context]]
-    #d = _load_dict(loadkey, cellid, batch)
-    #xfspec = [['nems_lbhb.xform_wrappers.baphy_load_wrapper', d]]
+    return [['nems.xforms.init_context', context]]
+
+
+def env(loadkey, cellid=None, batch=None, siteid=None, **options):
+    """
+    envelope loader
+       extra parameters handled by loadkey parser in baphy_load_wrapper
+    """
+
+    d = _load_dict(loadkey, cellid, batch)
+    xfspec = [['nems_lbhb.xform_wrappers.baphy_load_wrapper', d]]
     return xfspec
 
 
-def parm(loadkey, cellid=None, batch=None):
+def psth(loadkey, cellid=None, batch=None, siteid=None, **options):
+    """
+    psth loader (no stim)
+       extra parameters handled by loadkey parser in baphy_load_wrapper
+    """
+    return _parse_baphy_loadkey(loadkey, cellid=cellid, batch=batch, siteid=siteid, **options)
+
+    #d = _load_dict(loadkey, cellid, batch)
+    #xfspec = [['nems_lbhb.xform_wrappers.baphy_load_wrapper', d]]
+    #return xfspec
+
+
+def ozgf(loadkey, cellid=None, batch=None, siteid=None, **options):
+    """
+    gammatone filter
+       extra parameters handled by loadkey parser in baphy_load_wrapper
+    """
+    return _parse_baphy_loadkey(loadkey, cellid=cellid, batch=batch, siteid=siteid, **options)
+
+    #d = _load_dict(loadkey, cellid, batch)
+    #xfspec = [['nems_lbhb.xform_wrappers.baphy_load_wrapper', d]]
+    #return xfspec
+
+
+def parm(loadkey, cellid=None, batch=None, siteid=None, **options):
     """
     parm spectrogram
        extra parameters handled by loadkey parser in baphy_load_wrapper
@@ -86,7 +95,7 @@ def parm(loadkey, cellid=None, batch=None):
     return xfspec
 
 
-def ns(loadkey, cellid=None, batch=None):
+def ns(loadkey, cellid=None, batch=None, siteid=None, **options):
     d = _load_dict(loadkey, cellid, batch)
     xfspec = [['nems_lbhb.xform_wrappers.baphy_load_wrapper', d]]
     return xfspec

--- a/nems_lbhb/plugins/lbhb_loaders.py
+++ b/nems_lbhb/plugins/lbhb_loaders.py
@@ -1,6 +1,7 @@
 import logging
 import re
 
+
 log = logging.getLogger(__name__)
 
 
@@ -36,13 +37,42 @@ def psth(loadkey, cellid=None, batch=None):
     return xfspec
 
 
-def ozgf(loadkey, cellid=None, batch=None):
+def ozgf(loadkey, cellid=None, batch=None, siteid=None, **options):
     """
     gammatone filter
        extra parameters handled by loadkey parser in baphy_load_wrapper
     """
-    d = _load_dict(loadkey, cellid, batch)
-    xfspec = [['nems_lbhb.xform_wrappers.baphy_load_wrapper', d]]
+
+    from nems_lbhb.xform_wrappers import generate_recording_uri
+    import nems_lbhb.baphy as nb
+
+    pc_idx = None
+    if type(cellid) is str:
+        cc = cellid.split("_")
+        if (len(cc) > 1) and (cc[1][0] == "P"):
+            pc_idx = [int(cc[1][1:])]
+            cellid = cc[0]
+        elif (len(cellid.split('+')) > 1):
+            # list of cellids (specified in model queue by separating with '_')
+            cellid = cellid.split('+')
+
+    recording_uri = generate_recording_uri(cellid=cellid, batch=batch,
+                                           loadkey=loadkey, siteid=siteid)
+
+    # update the cellid in context so that we don't have to parse the cellid
+    # again in xforms
+    t_ops = {} # options.copy()
+    t_ops['cellid'] = cellid
+    t_ops['batch'] = batch
+    cells_to_extract, _ = nb.parse_cellid(t_ops)
+    context = {'recording_uri_list': [recording_uri], 'cellid': cells_to_extract}
+
+    if pc_idx is not None:
+        context['pc_idx'] = pc_idx
+
+    xfspec = [['nems.xforms.init_context', context]]
+    #d = _load_dict(loadkey, cellid, batch)
+    #xfspec = [['nems_lbhb.xform_wrappers.baphy_load_wrapper', d]]
     return xfspec
 
 

--- a/nems_lbhb/xform_wrappers.py
+++ b/nems_lbhb/xform_wrappers.py
@@ -248,7 +248,7 @@ def baphy_load_wrapper(cellid=None, batch=None, loadkey=None,
         elif (len(cellid.split('+')) > 1):
             # list of cellids (specified in model queue by separating with '_')
             cellid = cellid.split('+')
-    
+
     recording_uri = generate_recording_uri(cellid=cellid, batch=batch,
                                            loadkey=loadkey, siteid=siteid, **options)
 


### PR DESCRIPTION
Move baphy/celldb-specific processing from xforms into keyword evaluation. This will simplify exporting/sharing models because they can be reloaded without any LBHB dependencies.