### PR TITLE
Motor artifacts

### DIFF
--- a/nems_lbhb/baphy_experiment.py
+++ b/nems_lbhb/baphy_experiment.py
@@ -482,26 +482,45 @@ class BAPHYExperiment:
                     signals['resp'] = signals['resp'].append_time(r)
             
         if pupil:
-            
-            p_traces = self.get_pupil_trace(exptevents=exptevents, **kwargs)
-            pupil_sigs = [nems.signal.RasterizedSignal(
-                          fs=kwargs['rasterfs'], data=p[0],
-                          name='pupil', recording=rec_name, chans=['pupil'],
-                          epochs=baphy_events[i])
-                          for (i, p) in enumerate(p_traces)]
-            # make sure each pupil signal is the same len as resp, if resp exists
-            if resp:
-                for i, (p, r) in enumerate(zip(pupil_sigs, resp_sigs)):
+
+            def check_length(ps, rs):
+                for i, (p, r) in enumerate(zip(ps, rs)):
                     rlen = r.ntimes
                     plen = p.as_continuous().shape[1]
                     if plen > rlen:
-                        pupil_sigs[i] = p._modified_copy(p.as_continuous()[:, 0:-(plen-rlen)])
+                        ps[i] = p._modified_copy(p.as_continuous()[:, 0:-(plen-rlen)])
                     elif rlen > plen:
                         pcount = p.as_continuous().shape[0]
-                        pupil_sigs[i] = p._modified_copy(np.append(p.as_continuous(), 
+                        ps[i] = p._modified_copy(np.append(p.as_continuous(), 
                                                 np.ones([pcount, rlen - plen]) * np.nan, axis=1))
+                return ps
+            
+            p_traces = self.get_pupil_trace(exptevents=exptevents, **kwargs)
+            if type(p_traces[0][0]) is not np.ndarray:
+                # multiple 'pupil signals'
+                for sig in p_traces[0][0].keys():
+                    pupil_sigs = [nems.signal.RasterizedSignal(
+                                fs=kwargs['rasterfs'], data=p[0][sig],
+                                name=sig, recording=rec_name, chans=[sig],
+                                epochs=baphy_events[i])
+                                for (i, p) in enumerate(p_traces)]
+                    # make sure each pupil signal is the same len as resp, if resp exists
+                    if resp:
+                        pupil_sigs = check_length(pupil_sigs, resp_sigs)
 
-            signals['pupil'] = nems.signal.RasterizedSignal.concatenate_time(pupil_sigs)
+                    signals[sig] = nems.signal.RasterizedSignal.concatenate_time(pupil_sigs)
+
+            else:
+                pupil_sigs = [nems.signal.RasterizedSignal(
+                            fs=kwargs['rasterfs'], data=p[0],
+                            name='pupil', recording=rec_name, chans=['pupil'],
+                            epochs=baphy_events[i])
+                            for (i, p) in enumerate(p_traces)]
+                # make sure each pupil signal is the same len as resp, if resp exists
+                if resp:
+                    pupil_sigs = check_length(pupil_sigs, resp_sigs)
+
+                signals['pupil'] = nems.signal.RasterizedSignal.concatenate_time(pupil_sigs)
 
         if stim:
             #import pdb; pdb.set_trace()

--- a/nems_lbhb/baphy_experiment.py
+++ b/nems_lbhb/baphy_experiment.py
@@ -357,7 +357,8 @@ class BAPHYExperiment:
         kwargs = io.fill_default_options(kwargs)
 
         # add BAPHYExperiment version to recording options
-        kwargs.update({'version': 'BAPHYExperiment.2'})
+        # kwargs.update({'version': 'BAPHYExperiment.2'})
+        kwargs.update({'version': 'BAPHYExperiment.3'}) # version 3 added pupil extras to recording signals
 
         # add parmfiles / cells_to_load list - these are unique ids for the recording
         kwargs.update({'mfiles': [str(i) for i in self.parmfile]})

--- a/nems_lbhb/baphy_io.py
+++ b/nems_lbhb/baphy_io.py
@@ -1221,15 +1221,24 @@ def load_pupil_trace(pupilfilepath, exptevents=None, **options):
                 pupil_diameter[arg] = pupil_diameter[arg - 1]
 
         pupil_diameter = pupil_diameter[:-1, np.newaxis]
-        if pupildata['cnn']['excluded_frames'].size:
-            # there are frames that were excluded. Make a bool signal
-            # indicating these frames so that they can be removed if 
-            # wanted
-            log.info("Found pupil artifacts -- frames labeled as 'bad' in pupil_browser")
-            artifacts = np.zeros(pupil_diameter.shape).astype(bool)
-            for a in pupildata['cnn']['excluded_frames']:
-                artifacts[a[0]:a[1]] = True
-            
+        pupil_extras_keys = ['excluded_frames', 'pupil_eyespeed', 
+                                'eyelid_left_x', 'eyelid_left_y',
+                                'eyelid_top_x', 'eyelid_top_y',
+                                'eyelid_right_x', 'eyelid_right_y',
+                                'eyelid_bottom_x', 'eyelid_bottom_y']
+        pupil_extras = {}
+        for k in pupil_extras_keys:
+            if pupildata['cnn'][k].size:
+                log.info("Found extra pupil signal: {k}, loading into signal pupil extras")
+                if k == 'excluded_frames':
+                    # special case here, because not a time course
+                    artifacts = np.zeros(pupil_diameter.shape).astype(bool)
+                    for a in pupildata['cnn']['excluded_frames']:
+                        artifacts[a[0]:a[1]] = True
+                    pupil_extras[k] = artifacts
+                else:
+                    pupil_extras[k] = pupildata['cnn'][k]
+        
         log.info("pupil_diameter.shape: " + str(pupil_diameter.shape))
 
         if pupil_eyespeed:

--- a/nems_lbhb/baphy_io.py
+++ b/nems_lbhb/baphy_io.py
@@ -1096,7 +1096,10 @@ def set_default_pupil_options(options):
     options["rasterfs"] = options.get('rasterfs', 100)
     options['pupil'] = options.get('pupil', 1)
     options['pupil_analysis_method'] = options.get('pupil_analysis_method', 'cnn')  # or 'matlab'
-    options['pupil_variable_name'] = options.get('pupil_variable_name', 'minor_axis')
+    if options['pupil_analysis_method'] == 'cnn':
+        options['pupil_variable_name'] = options.get('pupil_variable_name', 'area')
+    else:
+        options['pupil_variable_name'] = options.get('pupil_variable_name', 'minor_axis')
     options["pupil_offset"] = options.get('pupil_offset', 0.75)
     options["pupil_deblink"] = options.get('pupil_deblink', True)
     options["pupil_deblink_dur"] = options.get('pupil_deblink_dur', 1)

--- a/nems_lbhb/baphy_io.py
+++ b/nems_lbhb/baphy_io.py
@@ -1248,9 +1248,11 @@ def load_pupil_trace(pupilfilepath, exptevents=None, **options):
 
         matdata = scipy.io.loadmat(pupilfilepath)
 
+        pupil_extras = {} # for backwards compaitbility with the new pupil fits
+
         p = matdata['pupil_data']
         params = p['params']
-        if 'pupil_variable_name' not in options:
+        if ('pupil_variable_name' not in options) | (options['pupil_variable_name']=='area'):
             options['pupil_variable_name'] = params[0][0]['default_var'][0][0][0]
             log.debug("Using default pupil_variable_name: %s", options['pupil_variable_name'])
         if 'pupil_algorithm' not in options:

--- a/nems_lbhb/celldb.py
+++ b/nems_lbhb/celldb.py
@@ -45,47 +45,30 @@ def update_table(tablename, key, value, **datadict):
     :return:
     """
     session = db.Session()
-    gSingleCell = LBHB_Tables()['gSingleCell']
+    t = LBHB_Tables()[tablename]
 
-    session.query(gSingleCell).\
-        filter(gSingleCell.cellid == cellid).\
-        update(datadict)
+    session.query(t).filter(getattr(t, key) == value).update(datadict)
 
     session.commit()
-
-
-
 
 
 def update_single_cell_data(cellid, **datadict):
     """
     :param cellid: eg, 'TAR010c-01-1' (should be an existing cellid)
     :param datadict: eg, {'layer': '2/3', 'phototag': 'E, mdlx', 'spikeshape': '0.122,0.328,0.309'}
-          keys must match existing columns of gSingleCell (the table that stores site properties)
+        keys must match existing columns of gSingleCell (the table that stores cell properties)
     :return:
     """
-    session = db.Session()
-    gSingleCell = LBHB_Tables()['gSingleCell']
+    update_table('gSingleCell', 'cellid', cellid, **datadict)
 
-    session.query(gSingleCell).\
-        filter(gSingleCell.cellid == cellid).\
-        update(datadict)
-
-    session.commit()
+    return
 
 def update_site_data(siteid, **datadict):
     """
     :param siteid: eg, 'TAR010c' (should be an existing siteid)
-    :param datadict: eg, {'layer': '2/3', 'phototag': 'E, mdlx', 'spikeshape': '0.122,0.328,0.309'}
-        keys must match existing columns of gSingleCell (the table that stores site properties)
+    :param datadict: eg, {'channeldepths': '1050,1000,1000,...0', 'layerboundaries': '200,500,800'}
+        keys must match existing columns of gCellMaster (the table that stores site properties)
     :return:
     """
-    session = db.Session()
-    gSingleCell = LBHB_Tables()['gSingleCell']
-
-    session.query(gSingleCell).\
-        filter(gSingleCell.cellid == cellid).\
-        update(datadict)
-
-    session.commit()
+    update_table('gCellMaster', 'siteid', siteid, **datadict)
 

--- a/nems_lbhb/plugins/lbhb_loaders.py
+++ b/nems_lbhb/plugins/lbhb_loaders.py
@@ -383,9 +383,9 @@ def loadpred(loadkey):
         if op == 'a':
             pc_format="all"
         if op == 'cpn':
-            dmask = 'epcpn-hrc'
+            dmask = 'epcpn-'+dmask
         if op == 'cpnmvm':
-            dmask = 'epcpn-mvm-hrc'
+            dmask = 'epcpn-mvm.25.2-hrc'
     if pc_count > 0:
         modelname_existing = f"psth.fs4.pup-ld-st.pup-{dmask}-pca.{pc_format}.cc{pc_count}-psthfr-aev_sdexp2.SxR_newtf.n.lr3e4.cont.et5.i50000"
     elif 'z' in ops:

--- a/nems_lbhb/plugins/lbhb_loaders.py
+++ b/nems_lbhb/plugins/lbhb_loaders.py
@@ -384,6 +384,8 @@ def loadpred(loadkey):
             pc_format="all"
         if op == 'cpn':
             dmask = 'epcpn-hrc'
+        if op == 'cpnmvm':
+            dmask = 'epcpn-mvm-hrc'
     if pc_count > 0:
         modelname_existing = f"psth.fs4.pup-ld-st.pup-{dmask}-pca.{pc_format}.cc{pc_count}-psthfr-aev_sdexp2.SxR_newtf.n.lr3e4.cont.et5.i50000"
     elif 'z' in ops:

--- a/nems_lbhb/plugins/lbhb_loaders.py
+++ b/nems_lbhb/plugins/lbhb_loaders.py
@@ -404,7 +404,7 @@ def loadpred(loadkey):
         if op == 'cpn':
             dmask = 'epcpn-'+dmask
         if op == 'cpnmvm':
-            dmask = 'epcpn-mvm.25.2-hrc'
+            dmask = 'epcpn-mvm.t25.w2-hrc'
     if pc_count > 0:
         modelname_existing = f"psth.fs4.pup-ld-st.pup-{dmask}-pca.{pc_format}.cc{pc_count}-psthfr-aev_sdexp2.SxR_newtf.n.lr3e4.cont.et5.i50000"
     elif 'z' in ops:

--- a/nems_lbhb/plugins/lbhb_postprocessors.py
+++ b/nems_lbhb/plugins/lbhb_postprocessors.py
@@ -60,6 +60,7 @@ def tfheld(loadkey):
     freeze_layers = None
     options = loadkey.split('.')
     use_matched_site = False
+    use_matched_random = False
     for op in options[1:]:
         if op.startswith('FL'):
             if ':' in op:
@@ -71,7 +72,10 @@ def tfheld(loadkey):
                 freeze_layers = [int(i) for i in op[2:].split('x')]
         elif op == 'ms':
             use_matched_site = True
+        elif op == 'rnd':
+            use_matched_random = True
 
     xfspec = [['nems_lbhb.xform_wrappers.switch_to_heldout_data', {'freeze_layers': freeze_layers,
-                                                                   'use_matched_site': use_matched_site}]]
+                                                                   'use_matched_site': use_matched_site,
+                                                                   'use_matched_random': use_matched_random}]]
     return xfspec

--- a/nems_lbhb/plugins/lbhb_postprocessors.py
+++ b/nems_lbhb/plugins/lbhb_postprocessors.py
@@ -57,21 +57,21 @@ def popspc(loadkey):
 
 @xform()
 def tfheld(loadkey):
-    trainable_layers = None
+    freeze_layers = None
     options = loadkey.split('.')
     use_matched_site = False
     for op in options[1:]:
-        if op.startswith('TL'):
+        if op.startswith('FL'):
             if ':' in op:
-                # ex: TL0:5  would be trainable_layers = [0,1,2,3,4]
+                # ex: FL0:5  would be freeze_layers = [0,1,2,3,4]
                 lower, upper = [int(i) for i in op[2:].split(':')]
-                trainable_layers = list(range(lower, upper))
+                freeze_layers = list(range(lower, upper))
             else:
                 # ex: TL2x6x9  would be trainable_layers = [2, 6, 9]
-                trainable_layers = [int(i) for i in op[2:].split('x')]
+                freeze_layers = [int(i) for i in op[2:].split('x')]
         elif op == 'ms':
             use_matched_site = True
 
-    xfspec = [['nems_lbhb.xform_wrappers.switch_to_heldout_data', {'trainable_layers': trainable_layers,
+    xfspec = [['nems_lbhb.xform_wrappers.switch_to_heldout_data', {'freeze_layers': freeze_layers,
                                                                    'use_matched_site': use_matched_site}]]
     return xfspec

--- a/nems_lbhb/plugins/lbhb_preprocessors.py
+++ b/nems_lbhb/plugins/lbhb_preprocessors.py
@@ -499,6 +499,35 @@ def plgsm(load_key):
 
     return xfspec
 
+@xform()
+def mvm(load_key):
+    """
+    Create masks for movement artifacts
+    """
+    ops = load_key.split('.')[1:]
+    binsize = 1
+    threshold = 0.25
+    for op in ops:
+        if op.startswith('t'):
+            # threshold
+            tkey = float(op[1:])
+            if tkey == 1:
+                threshold = tkey
+            else:
+                threshold = tkey / 100
+        if op.startswith('w'):
+            # window size in sec
+            wkey = float(op[1:])
+            if tkey > 10:
+                binsize = wkey / 100
+            else:
+                binsize = wkey 
+
+    xfspec = [['nems_lbhb.preprocessing.movement_mask', 
+               {'threshold': threshold, 'binsize': binsize}]]
+
+    return xfspec
+
 
 @xform()
 def ev(load_key):

--- a/nems_lbhb/plugins/lbhb_preprocessors.py
+++ b/nems_lbhb/plugins/lbhb_preprocessors.py
@@ -519,11 +519,11 @@ def mvm(load_key):
         if op.startswith('w'):
             # window size in sec
             wkey = float(op[1:])
-            if tkey > 10:
+            if wkey > 10:
                 binsize = wkey / 100
             else:
                 binsize = wkey 
-
+    
     xfspec = [['nems_lbhb.preprocessing.movement_mask', 
                {'threshold': threshold, 'binsize': binsize}]]
 

--- a/nems_lbhb/preprocessing.py
+++ b/nems_lbhb/preprocessing.py
@@ -39,7 +39,7 @@ def append_difficulty(rec, **kwargs):
     newrec['hard_trials'] = resp.epoch_to_signal('HARD_BEHAVIOR')
     newrec['hard_trials'].chans = ['hard_trials']
 
-def fix_cpn_epochs(rec, sequence_only=True, **kwargs):
+def fix_cpn_epochs(rec, sequence_only=False, **kwargs):
     """
     Specialized preprocessor for CPN data to make the epoch names match more 
     "traditional" baphy format.

--- a/nems_lbhb/preprocessing.py
+++ b/nems_lbhb/preprocessing.py
@@ -1002,7 +1002,7 @@ def movement_mask(rec, binsize=1, threshold=0.25, **kwargs):
     r['varsig'] = r['pupil']._modified_copy(varsig)
     threshold = np.std(varsig) * threshold
     mask = varsig >= threshold
-    log.info(f"Found {mask.sum() / mask.shape[-1]} bins that violated movement threshold")
+    log.info(f"Found {mask.sum()} / {mask.shape[-1]} bins that violated movement threshold")
 
     # tile mask over generic epochs (REFERENCE, TARGET, CATCH)
     epochs = [e for e in ['REFERENCE', 'TARGET', 'CATCH'] if e in r['resp'].epochs.name.unique()]

--- a/nems_lbhb/preprocessing.py
+++ b/nems_lbhb/preprocessing.py
@@ -1002,6 +1002,7 @@ def movement_mask(rec, binsize=1, threshold=0.25, **kwargs):
     r['varsig'] = r['pupil']._modified_copy(varsig)
     threshold = np.std(varsig) * threshold
     mask = varsig >= threshold
+    log.info(f"Found {mask.sum() / mask.shape[-1]} bins that violated movement threshold")
 
     # tile mask over generic epochs (REFERENCE, TARGET, CATCH)
     epochs = [e for e in ['REFERENCE', 'TARGET', 'CATCH'] if e in r['resp'].epochs.name.unique()]

--- a/nems_lbhb/preprocessing.py
+++ b/nems_lbhb/preprocessing.py
@@ -63,7 +63,7 @@ def fix_cpn_epochs(rec, sequence_only=False, **kwargs):
         # strip the seq. epochs and sub pre/post stim
         new_epochs = new_epochs[~new_epochs.name.str.contains('_sequence')]
 
-        # remove "sub" labels
+        # remove "sub" labels -- sub masks finds SubPreStimSilence and SubPostStimSilence
         sub = new_epochs.name.str.startswith('Sub')
         new_epochs.at[sub, 'name'] = [s.strip('Sub') for s in new_epochs[sub].name]
 
@@ -75,6 +75,11 @@ def fix_cpn_epochs(rec, sequence_only=False, **kwargs):
         one_bin = np.float(1 / rec['resp'].fs)
         new_epochs.at[stim_mask, 'start'] = new_epochs.loc[stim_mask, 'start'].values + one_bin
         new_epochs.at[sub, 'start'] = new_epochs.loc[sub, 'start'].values + one_bin
+        # looks like was never actually dealing with prestim silence correctly, which resulted
+        # in prestim silence epochs with negative length. Oops. Fixing that now -- crh 06.28.2021
+        # reason this happened is that sub pre/post stim are length zero for this data, so I forgot
+        # to update the end timestamp too.
+        new_epochs.at[sub, 'end'] = new_epochs.loc[sub, 'end'].values + one_bin
 
     else:
         new_epochs = new_epochs[~new_epochs.name.str.contains('_probe')]

--- a/nems_lbhb/preprocessing.py
+++ b/nems_lbhb/preprocessing.py
@@ -1003,6 +1003,8 @@ def movement_mask(rec, binsize=1, threshold=0.25, **kwargs):
                         for i in range(v.shape[0])], axis=0) 
                         for k, v in fm.items()}
     rec['var_mask'] = rec['var_mask'].replace_epochs(fm)
+    if 'mask' not in r.signals:
+        r = r.create_mask(True)
     r['mask'] = r['mask']._modified_copy(r['mask']._data & rec['var_mask']._data)
 
     return {'rec': r}

--- a/nems_lbhb/preprocessing.py
+++ b/nems_lbhb/preprocessing.py
@@ -631,7 +631,6 @@ def create_pupil_mask(rec, evoked_only=False, **options):
 
     elif (collapse is True) & (epoch is not None):
         log.info('collapsing over all {0} epochs and tiling mean pupil per epoch'.format(epoch))
-
         # In this case, fold pupil first based on the epoch(s)
         folded_pupil = r['pupil'].extract_epochs(epoch)
 

--- a/nems_lbhb/pup_py/batch_norm.py
+++ b/nems_lbhb/pup_py/batch_norm.py
@@ -9,65 +9,68 @@ import pupil_settings as ps
 import nems_lbhb.pup_py.utils as ut
 # load all training video frames so that we can get the mean / sd of each ellipse paramter.
 # this way we can z-score the paramters so that they're evenly weighted during the fit
-training_files = os.listdir(ps.TRAIN_DATA_PATH)
 
-y = np.zeros((len(training_files), 13))
-for i, f in enumerate(training_files):
-    fp = open(os.path.join(ps.TRAIN_DATA_PATH+f), "rb")
-    current_frame = pickle.load(fp)
 
-    scale_fact, im = ut.resize(current_frame['frame'], size=(224, 224))
-    
-    # load labels (ellipse params)
-    Y0_in = current_frame['ellipse_zack']['Y0_in']
-    X0_in = current_frame['ellipse_zack']['X0_in']
-    long_axis = current_frame['ellipse_zack']['b'] * 2
-    short_axis = current_frame['ellipse_zack']['a'] * 2
-    phi = current_frame['ellipse_zack']['phi']
-    # eyelid keypoints
-    lx = current_frame['ellipse_zack']['eyelid_left_x']
-    ly = current_frame['ellipse_zack']['eyelid_left_y']
-    tx = current_frame['ellipse_zack']['eyelid_top_x']
-    ty = current_frame['ellipse_zack']['eyelid_top_y']
-    rx = current_frame['ellipse_zack']['eyelid_right_x']
-    ry = current_frame['ellipse_zack']['eyelid_right_y']
-    bx = current_frame['ellipse_zack']['eyelid_bottom_x']
-    by = current_frame['ellipse_zack']['eyelid_bottom_y']
-    y[i, :] = np.asarray([Y0_in, X0_in, long_axis, short_axis, phi,
-                    lx, ly, tx, ty, rx, ry, bx, by])
+def get_batch_norm_params(species):
+    training_files = os.listdir(os.path.join(ps.ROOT_DIRECTORY, species, 'training_data/'))
+    y = np.zeros((len(training_files), 13))
+    for i, f in enumerate(training_files):
+        fp = open(os.path.join(ps.ROOT_DIRECTORY, species, 'training_data', f), "rb")
+        current_frame = pickle.load(fp)
 
-    y[i, ] = np.asarray([y[i, 0] * scale_fact[1], y[i, 1] * scale_fact[0], y[i, 2] * scale_fact[1],
-                        y[i, 3] * scale_fact[0], y[i, 4],
-                        y[i, 5] * scale_fact[0],
-                        y[i, 6] * scale_fact[1],
-                        y[i, 7] * scale_fact[0],
-                        y[i, 8] * scale_fact[1],
-                        y[i, 9] * scale_fact[0],
-                        y[i, 10] * scale_fact[1],
-                        y[i, 11] * scale_fact[0],
-                        y[i, 12] * scale_fact[1],
-                        ])
+        scale_fact, im = ut.resize(current_frame['frame'], size=(224, 224))
+        
+        # load labels (ellipse params)
+        Y0_in = current_frame['ellipse_zack']['Y0_in']
+        X0_in = current_frame['ellipse_zack']['X0_in']
+        long_axis = current_frame['ellipse_zack']['b'] * 2
+        short_axis = current_frame['ellipse_zack']['a'] * 2
+        phi = current_frame['ellipse_zack']['phi']
+        # eyelid keypoints
+        lx = current_frame['ellipse_zack']['eyelid_left_x']
+        ly = current_frame['ellipse_zack']['eyelid_left_y']
+        tx = current_frame['ellipse_zack']['eyelid_top_x']
+        ty = current_frame['ellipse_zack']['eyelid_top_y']
+        rx = current_frame['ellipse_zack']['eyelid_right_x']
+        ry = current_frame['ellipse_zack']['eyelid_right_y']
+        bx = current_frame['ellipse_zack']['eyelid_bottom_x']
+        by = current_frame['ellipse_zack']['eyelid_bottom_y']
+        y[i, :] = np.asarray([Y0_in, X0_in, long_axis, short_axis, phi,
+                        lx, ly, tx, ty, rx, ry, bx, by])
 
-# now, get the normalization factors for each parm in format:
-# key: (mean, sd)
-keys = [
-    'Y0_in',
-    'X0_in',
-    'b',
-    'a',
-    'phi',
-    'eyelid_left_x',
-    'eyelid_left_y',
-    'eyelid_top_x',
-    'eyelid_top_y',
-    'eyelid_right_x',
-    'eyelid_right_y',
-    'eyelid_bottom_x',
-    'eyelid_bottom_y'
-]
-NORM_FACTORS = {}
-for i, k in enumerate(keys):
-    m = y[:, i].mean()
-    sd = y[:, i].std()
-    ma = y[:, i].max()
-    NORM_FACTORS[k] = (m, sd, ma)
+        y[i, ] = np.asarray([y[i, 0] * scale_fact[1], y[i, 1] * scale_fact[0], y[i, 2] * scale_fact[1],
+                            y[i, 3] * scale_fact[0], y[i, 4],
+                            y[i, 5] * scale_fact[0],
+                            y[i, 6] * scale_fact[1],
+                            y[i, 7] * scale_fact[0],
+                            y[i, 8] * scale_fact[1],
+                            y[i, 9] * scale_fact[0],
+                            y[i, 10] * scale_fact[1],
+                            y[i, 11] * scale_fact[0],
+                            y[i, 12] * scale_fact[1],
+                            ])
+
+    # now, get the normalization factors for each parm in format:
+    # key: (mean, sd)
+    keys = [
+        'Y0_in',
+        'X0_in',
+        'b',
+        'a',
+        'phi',
+        'eyelid_left_x',
+        'eyelid_left_y',
+        'eyelid_top_x',
+        'eyelid_top_y',
+        'eyelid_right_x',
+        'eyelid_right_y',
+        'eyelid_bottom_x',
+        'eyelid_bottom_y'
+    ]
+    NORM_FACTORS = {}
+    for i, k in enumerate(keys):
+        m = y[:, i].mean()
+        sd = y[:, i].std()
+        ma = y[:, i].max()
+        NORM_FACTORS[k] = (m, sd, ma)
+    return NORM_FACTORS

--- a/nems_lbhb/pup_py/batch_norm.py
+++ b/nems_lbhb/pup_py/batch_norm.py
@@ -1,0 +1,73 @@
+import pickle
+import numpy as np
+import os
+import sys
+import nems_db
+nems_db_path = nems_db.__file__.split('/nems_db/__init__.py')[0]
+sys.path.append(os.path.join(nems_db_path, 'nems_lbhb/pup_py/'))
+import pupil_settings as ps
+import nems_lbhb.pup_py.utils as ut
+# load all training video frames so that we can get the mean / sd of each ellipse paramter.
+# this way we can z-score the paramters so that they're evenly weighted during the fit
+training_files = os.listdir(ps.TRAIN_DATA_PATH)
+
+y = np.zeros((len(training_files), 13))
+for i, f in enumerate(training_files):
+    fp = open(os.path.join(ps.TRAIN_DATA_PATH+f), "rb")
+    current_frame = pickle.load(fp)
+
+    scale_fact, im = ut.resize(current_frame['frame'], size=(224, 224))
+    
+    # load labels (ellipse params)
+    Y0_in = current_frame['ellipse_zack']['Y0_in']
+    X0_in = current_frame['ellipse_zack']['X0_in']
+    long_axis = current_frame['ellipse_zack']['b'] * 2
+    short_axis = current_frame['ellipse_zack']['a'] * 2
+    phi = current_frame['ellipse_zack']['phi']
+    # eyelid keypoints
+    lx = current_frame['ellipse_zack']['eyelid_left_x']
+    ly = current_frame['ellipse_zack']['eyelid_left_y']
+    tx = current_frame['ellipse_zack']['eyelid_top_x']
+    ty = current_frame['ellipse_zack']['eyelid_top_y']
+    rx = current_frame['ellipse_zack']['eyelid_right_x']
+    ry = current_frame['ellipse_zack']['eyelid_right_y']
+    bx = current_frame['ellipse_zack']['eyelid_bottom_x']
+    by = current_frame['ellipse_zack']['eyelid_bottom_y']
+    y[i, :] = np.asarray([Y0_in, X0_in, long_axis, short_axis, phi,
+                    lx, ly, tx, ty, rx, ry, bx, by])
+
+    y[i, ] = np.asarray([y[i, 0] * scale_fact[1], y[i, 1] * scale_fact[0], y[i, 2] * scale_fact[1],
+                        y[i, 3] * scale_fact[0], y[i, 4],
+                        y[i, 5] * scale_fact[0],
+                        y[i, 6] * scale_fact[1],
+                        y[i, 7] * scale_fact[0],
+                        y[i, 8] * scale_fact[1],
+                        y[i, 9] * scale_fact[0],
+                        y[i, 10] * scale_fact[1],
+                        y[i, 11] * scale_fact[0],
+                        y[i, 12] * scale_fact[1],
+                        ])
+
+# now, get the normalization factors for each parm in format:
+# key: (mean, sd)
+keys = [
+    'Y0_in',
+    'X0_in',
+    'b',
+    'a',
+    'phi',
+    'eyelid_left_x',
+    'eyelid_left_y',
+    'eyelid_top_x',
+    'eyelid_top_y',
+    'eyelid_right_x',
+    'eyelid_right_y',
+    'eyelid_bottom_x',
+    'eyelid_bottom_y'
+]
+NORM_FACTORS = {}
+for i, k in enumerate(keys):
+    m = y[:, i].mean()
+    sd = y[:, i].std()
+    ma = y[:, i].max()
+    NORM_FACTORS[k] = (m, sd, ma)

--- a/nems_lbhb/pup_py/batch_process.py
+++ b/nems_lbhb/pup_py/batch_process.py
@@ -15,14 +15,14 @@ log = logging.getLogger(__name__)
 script_path = os.path.split(os.path.split(nems_db.__file__)[0])[0]
 script_path = os.path.join(script_path, 'nems_lbhb', 'pup_py', 'pupil_fit_script.py')
 
-def queue_pupil_jobs(pupilfiles, modeldate='Current', animal='All', python_path=None, username='nems', force_rerun=True):
+def queue_pupil_jobs(pupilfiles, modeldate='Current', species='ferret', animal='All', python_path=None, username='nems', force_rerun=True):
 
     if python_path is None:
         python_path = sys.executable  # path to python (can be set manually, but defaults to active python running
 
     for fn in pupilfiles:
         # add job to queue
-        nd.add_job_to_queue([fn, modeldate, animal], note="Pupil Job: {}".format(fn),
+        nd.add_job_to_queue([fn, modeldate, f"{species}_{animal}"], note="Pupil Job: {}".format(fn),
                             executable_path=python_path, user=username,
                             force_rerun=force_rerun, script_path=script_path, GPU_job=1)
 

--- a/nems_lbhb/pup_py/browse_training_data.py
+++ b/nems_lbhb/pup_py/browse_training_data.py
@@ -3,13 +3,14 @@ Script meant to be used for browsing saved training data and manually manipulati
 useful when you notice there is frame the must be manually annotated.
 '''
 import tkinter as tk
-import matplotlib.backends.tkagg as tkagg
+from matplotlib.backends import _backend_tk as tkagg
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 import os
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.patches import Ellipse
+from matplotlib.figure import Figure
 from PIL import Image
 import pickle
 import sys
@@ -30,7 +31,7 @@ class TrainingDataBrowser:
         # these 50 frames from this range. train frame range is tuple (start_frame, end_frame)
 
         self.plot_calls = 0
-
+        self.edgepoints = []        
         if (animal is None) and (video_name is None):
             self.from_browser = False
             default_frame = os.listdir(train_data_path)[0].split('.')[0]
@@ -82,15 +83,15 @@ class TrainingDataBrowser:
                 os.system("ffmpeg -ss {0} -i {1} -vframes 1 {2}{3}%d.jpg".format(t, video, tmp_save, video_name))
 
                 # load, convert to grayscale, cut off artifact, extact/save first channel only
-                img = Image.open(tmp_save + video_name + '1' + '.jpg').convert('LA')
+                img = Image.open(tmp_save + video_name + '1' + '.jpg') #.convert('LA')
                 frame = np.asarray(img)[:, :-10, 0]
                 output_dict['frame'] = frame
-                img2 = Image.open(tmp_save + video_name + '1' + '.jpg').convert('LA')
+                img2 = Image.open(tmp_save + video_name + '1' + '.jpg') #.convert('LA')
                 frame2 = np.asarray(img2)[:, :-10, 0]
                 output_dict['frame2'] = frame2  # for display purposes
                 output_dict['ellipse_zack'] = {
                                 'a': parms['cnn']['a'][f],
-                                'b': parms['cnn']['b'][f],
+                                'b': parms['cnn']['b'][f],  
                                 'X0_in': parms['cnn']['x'][f],
                                 'Y0_in': parms['cnn']['y'][f],
                                 'phi': parms['cnn']['phi'][f]
@@ -112,12 +113,13 @@ class TrainingDataBrowser:
         self.master = master
         master.title("Training data browser")
         master.geometry('950x400')
+        #master.geometry('1200x500')
 
         # create a plot attributemod
         self.pupil_plot = None
 
-        self.pupil_canvas = tk.Canvas(master, width=400, height=400)
-        self.pupil_canvas.grid(row=0, column=4, rowspan=11)
+        #self.pupil_canvas = tk.Canvas(master, width=300, height=300)
+        #self.pupil_canvas.grid(row=0, column=4, rowspan=11)
 
         self.load_button = tk.Button(master, text="Display current frame", command=self.browse_files)
         self.load_button.grid(row=0, column=1)
@@ -207,7 +209,7 @@ class TrainingDataBrowser:
         self.set_ellipse_prev.grid(row=9, column=1)
 
         # save new ellipse params for this frame
-        self.save_ellipse = tk.Button(master, text="Save new ellipse", command=self.save_ellipse_params)
+        self.save_ellipse = tk.Button(master, text="Save new parameters", command=self.save_ellipse_params)
         self.save_ellipse.grid(row=10, column=1)
 
         self.close_button = tk.Button(master, text="Close", command=master.destroy)
@@ -219,7 +221,7 @@ class TrainingDataBrowser:
         self.long_axis_value.delete(0, 'end')
         self.long_axis_value.insert(0, string=str(round(val, 2)))
 
-        self.pupil_canvas.delete(self.pupil_plot)
+        #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.update_ellipse_plot()
 
     def decrease_la(self):
@@ -228,7 +230,7 @@ class TrainingDataBrowser:
         self.long_axis_value.delete(0, 'end')
         self.long_axis_value.insert(0, string=str(round(val, 2)))
 
-        self.pupil_canvas.delete(self.pupil_plot)
+        #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.update_ellipse_plot()
 
     def increase_sa(self):
@@ -237,7 +239,7 @@ class TrainingDataBrowser:
         self.short_axis_value.delete(0, 'end')
         self.short_axis_value.insert(0, string=str(round(val, 2)))
 
-        self.pupil_canvas.delete(self.pupil_plot)
+        #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.update_ellipse_plot()
 
     def decrease_sa(self):
@@ -246,7 +248,7 @@ class TrainingDataBrowser:
         self.short_axis_value.delete(0, 'end')
         self.short_axis_value.insert(0, string=str(round(val, 2)))
 
-        self.pupil_canvas.delete(self.pupil_plot)
+        #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.update_ellipse_plot()
 
     def increase_x(self):
@@ -255,7 +257,7 @@ class TrainingDataBrowser:
         self.x_pos_value.delete(0, 'end')
         self.x_pos_value.insert(0, string=str(round(val, 2)))
 
-        self.pupil_canvas.delete(self.pupil_plot)
+        #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.update_ellipse_plot()
 
     def decrease_x(self):
@@ -264,7 +266,7 @@ class TrainingDataBrowser:
         self.x_pos_value.delete(0, 'end')
         self.x_pos_value.insert(0, string=str(round(val, 2)))
 
-        self.pupil_canvas.delete(self.pupil_plot)
+        #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.update_ellipse_plot()
 
     def increase_y(self):
@@ -273,7 +275,7 @@ class TrainingDataBrowser:
         self.y_pos_value.delete(0, 'end')
         self.y_pos_value.insert(0, string=str(round(val, 2)))
 
-        self.pupil_canvas.delete(self.pupil_plot)
+        #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.update_ellipse_plot()
 
     def decrease_y(self):
@@ -282,7 +284,7 @@ class TrainingDataBrowser:
         self.y_pos_value.delete(0, 'end')
         self.y_pos_value.insert(0, string=str(round(val, 2)))
 
-        self.pupil_canvas.delete(self.pupil_plot)
+        #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.update_ellipse_plot()
 
     def increase_phi(self):
@@ -291,7 +293,7 @@ class TrainingDataBrowser:
         self.phi_value.delete(0, 'end')
         self.phi_value.insert(0, string=str(round(val, 2)))
 
-        self.pupil_canvas.delete(self.pupil_plot)
+        #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.update_ellipse_plot()
 
     def decrease_phi(self):
@@ -300,7 +302,7 @@ class TrainingDataBrowser:
         self.phi_value.delete(0, 'end')
         self.phi_value.insert(0, string=str(round(val, 2)))
 
-        self.pupil_canvas.delete(self.pupil_plot)
+        #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.update_ellipse_plot()
 
 
@@ -347,7 +349,7 @@ class TrainingDataBrowser:
         
         self.update_ellipse_params(prev_params['ellipse_zack'])
 
-        self.pupil_canvas.delete(self.pupil_plot)
+        #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.update_ellipse_plot()
 
     def save_ellipse_params(self):
@@ -357,13 +359,27 @@ class TrainingDataBrowser:
         long_axis = np.float(self.long_axis_value.get())
         short_axis = np.float(self.short_axis_value.get())
         phi = np.float(self.phi_value.get()) / 180 * np.pi
-
+        # save eyelid key points
+        self.sort_edgepoints()
+        left = self.edgepoints[0]
+        top = self.edgepoints[1]
+        right = self.edgepoints[2]
+        bottom = self.edgepoints[3]
+        print(self.edgepoints)
         e_params = {
             'X0_in': X0_in,
             'Y0_in': Y0_in,
             'b': (long_axis / 2),
             'a': (short_axis / 2),
-            'phi': phi
+            'phi': phi,
+            'eyelid_left_x': left[0],
+            'eyelid_left_y': left[1],
+            'eyelid_top_x': top[0],
+            'eyelid_top_y': top[1],
+            'eyelid_right_x': right[0],
+            'eyelid_right_y': right[1],
+            'eyelid_bottom_x': bottom[0],
+            'eyelid_bottom_y': bottom[1],
         }
 
         frame_file = self.frame_name.get()
@@ -372,6 +388,8 @@ class TrainingDataBrowser:
             current_params = pickle.load(fp)
 
         new_params = current_params.copy()
+        # old naming convention leftover from Leah's MATLAB pupil analysis 
+        # which served as first training data for this.
         new_params['ellipse_zack'] = e_params
 
         with open(train_data_path+'{0}.pickle'.format(frame_file), 'wb') as fp:
@@ -390,8 +408,8 @@ class TrainingDataBrowser:
         with open('{0}/{1}.pickle'.format(train_data_path, frame_file), 'rb') as fp:
             frame_data = pickle.load(fp)
 
-        canvas = self.pupil_canvas
-        canvas.delete('all') # prevent memory leak
+        #canvas = self.pupil_canvas
+        #canvas.delete('all') # prevent memory leak
         loc = (0, 0)
 
         X0_in = np.float(self.y_pos_value.get())  # these are flipped on purpose
@@ -400,50 +418,38 @@ class TrainingDataBrowser:
         short_axis = np.float(self.short_axis_value.get())
         phi = np.float(self.phi_value.get()) / 180 * np.pi
 
+        if self.edgepoints == []:
+            self.edgepoints = get_eyelid_keypoints(frame_data)
 
-        if self.plot_calls == 0:
-            self.plot_calls += 1
-            self.figure_handle = mpl.figure.Figure(figsize=(4, 4))
-            self.ax_handle = self.figure_handle.add_axes([0, 0, 1, 1])
-            self.pupil_handle = self.ax_handle.imshow(frame_data['frame'])
-            ellipse = Ellipse((Y0_in, X0_in), long_axis, - short_axis, 180 * phi / np.pi, fill=False, color='red')
-            self.ax_handle.add_patch(ellipse)
+        self.plot_calls += 1
+        self.figure_handle = mpl.figure.Figure(figsize=(4, 4))
+        self.ax_handle = self.figure_handle.add_subplot(111)
+        self.pupil_handle = self.ax_handle.imshow(frame_data['frame'])
+        ellipse = Ellipse((Y0_in, X0_in), long_axis, - short_axis, 180 * phi / np.pi, fill=False, color='red')
+        self.ax_handle.plot(np.array(self.edgepoints)[:, 0],
+                                np.array(self.edgepoints)[:, 1], lw=0, marker='o', markersize=5, color='red')
+        self.ax_handle.add_patch(ellipse)
 
-            self.figure_canvas_agg = FigureCanvasTkAgg(self.figure_handle, master=self.master)
-        else:
-            self.pupil_handle.set_data(frame_data['frame'])
-            ellipse = Ellipse((Y0_in, X0_in), long_axis, - short_axis, 180 * phi / np.pi, fill=False, color='red')
-            self.ax_handle.patches[0].remove()
-            self.ax_handle.add_patch(ellipse)
+        self.figure_canvas_agg = FigureCanvasTkAgg(self.figure_handle, master=self.master)
 
         self.figure_canvas_agg.draw()
-
-        figure_x, figure_y, figure_w, figure_h = self.figure_handle.bbox.bounds
-        figure_w, figure_h = int(figure_w), int(figure_h)
-        photo = tk.PhotoImage(master=canvas, width=figure_w, height=figure_h)
-
-        # Position: convert from top-left anchor to center anchor
-        canvas.create_image(loc[0] + figure_w / 2, loc[1] + figure_h / 2, image=photo)
-
-        # Unfortunately, there's no accessor for the pointer to the native renderer
-        tkagg.blit(photo, self.figure_canvas_agg.get_renderer()._renderer, colormode=2)
-
-        # self.pupil_canvas = canvas
-
-        return photo
+        self.figure_canvas_agg.mpl_connect(
+                "button_press_event", self.button_press_callback)
+        self.figure_canvas_agg.mpl_connect(
+                "key_press_event", self.key_press_callback)
+        self.figure_canvas_agg.get_tk_widget().grid(row=0, column=4, rowspan=11, ipadx=0, ipady=0, pady=0, padx=0)
 
     def plot_frame(self, frame_file):
         '''
         with open(data_dict, 'rb') as fp:
             data = pickle.load(fp)
         '''
-
         with open('{0}/{1}.pickle'.format(train_data_path, frame_file), 'rb') as fp:
             frame_data = pickle.load(fp)
             fp.close()
 
-        canvas = self.pupil_canvas
-        canvas.delete('all')  # prevent memory leak
+        #canvas = self.pupil_canvas
+        #canvas.delete('all')  # prevent memory leak
         #if 'AMT003c11_p_NAT10995' in frame_file:
         #    import pdb; pdb.set_trace()
 
@@ -453,47 +459,83 @@ class TrainingDataBrowser:
         short_axis = frame_data['ellipse_zack']['a'] * 2
         phi = frame_data['ellipse_zack']['phi']
 
+        # load eyelid keypoints and pack into list of x, y coordinates
+        self.edgepoints = get_eyelid_keypoints(frame_data)
+
         # update the ellipse params display to correspond to the current frame
         self.update_ellipse_params(frame_data['ellipse_zack'])
 
         loc = (0, 0)
 
-        if self.plot_calls == 0:
-            self.plot_calls += 1
-            self.figure_handle = mpl.figure.Figure(figsize=(4, 4))
-            self.ax_handle = self.figure_handle.add_axes([0, 0, 1, 1])
-            try:
-                self.pupil_handle = self.ax_handle.imshow(frame_data['frame2'])
-            except:
-                self.pupil_handle = self.ax_handle.imshow(frame_data['frame'])
-            self.ax_handle.axis('off')
-            ellipse = Ellipse((Y0_in, X0_in), long_axis, - short_axis, 180 * phi / np.pi, fill=False, color='red')
-            self.ax_handle.add_patch(ellipse)
-            self.figure_canvas_agg = FigureCanvasTkAgg(self.figure_handle, master=self.master)
-        else:
-            try:
-                self.pupil_handle.set_data(frame_data['frame2'])
-            except:
-                self.pupil_handle.set_data(frame_data['frame'])
-            ellipse = Ellipse((Y0_in, X0_in), long_axis, - short_axis, 180 * phi / np.pi, fill=False, color='red')
-            self.ax_handle.patches[0].remove()
-            self.ax_handle.add_patch(ellipse)
+        self.plot_calls += 1
+        #self.figure_handle = mpl.figure.Figure(figsize=(4, 4))
+        #self.figure_handle = plt.Figure(figsize=(4, 4))
+        self.figure_handle = mpl.figure.Figure(figsize=(4, 4))
+        #self.ax_handle = self.figure_handle.add_axes([0, 0, 1, 1])
+        self.ax_handle = self.figure_handle.add_subplot(111)
+        try:
+            self.pupil_handle = self.ax_handle.imshow(frame_data['frame2'])
+        except:
+            self.pupil_handle = self.ax_handle.imshow(frame_data['frame'])
+        #self.ax_handle.axis('off')
+        self.ax_handle.plot(np.array(self.edgepoints)[:, 0],
+                                np.array(self.edgepoints)[:, 1], lw=0, marker='o', markersize=5, color='red')
+        ellipse = Ellipse((Y0_in, X0_in), long_axis, - short_axis, 180 * phi / np.pi, fill=False, color='red')
+        self.ax_handle.add_patch(ellipse)
+        self.figure_canvas_agg = FigureCanvasTkAgg(self.figure_handle, master=self.master)
 
         self.figure_canvas_agg.draw()
+        self.figure_canvas_agg.mpl_connect(
+                "button_press_event", self.button_press_callback)
+        self.figure_canvas_agg.mpl_connect(
+                "key_press_event", self.key_press_callback)
+        self.figure_canvas_agg.get_tk_widget().grid(row=0, column=4, rowspan=11, ipadx=0, ipady=0, pady=0, padx=0)
 
-        figure_x, figure_y, figure_w, figure_h = self.figure_handle.bbox.bounds
-        figure_w, figure_h = int(figure_w), int(figure_h)
-        photo = tk.PhotoImage(master=canvas, width=figure_w, height=figure_h)
 
-        # Position: convert from top-left anchor to center anchor
-        canvas.create_image(loc[0] + figure_w/2, loc[1] + figure_h/2, image=photo)
+    # button press callbacks
+    def button_press_callback(self, event):
+        # append location to polygon
+        try:
+            self.ax_handle.lines.pop(0)
+        except:
+            pass
 
-        # Unfortunately, there's no accessor for the pointer to the native renderer
-        tkagg.blit(photo, self.figure_canvas_agg.get_renderer()._renderer, colormode=2)
+        if len(self.edgepoints)>=4:
+            self.edgepoints = []
+            
+        self.edgepoints.append((event.xdata, event.ydata))
+        ep = np.array(self.edgepoints)
+        self.edgeline = self.ax_handle.plot(ep[:, 0], ep[:, 1], lw=0, marker='o', markersize=5, color='red')
+        
+        self.figure_canvas_agg.draw()
 
-        # self.pupil_canvas = canvas
+    def key_press_callback(self, event):
+        # remove polygon
+        if event.key == 'escape':
+            # empty the polygon array
+            self.edgepoints = []
+            try:
+                self.ax_handle.lines.pop(0)
+            except:
+                pass
+            self.figure_canvas_agg.draw()
 
-        return photo
+
+    def sort_edgepoints(self):
+        # helper function for sorting edgepoints so that the order is:
+        # 1 - left, 2 - top, 3 - right and 4 - bottom
+        # that way they're always in the same position for the fitter
+        # also, make sure they're not Nan (placeholders)
+        if (len(self.edgepoints)!=4) | np.any(np.isnan(np.array(self.edgepoints))):
+            raise ValueError("Must label all for edgepoints of the eyelid (left corner, middle-top, right corner, middle-bottom")
+        xlocs = np.array(self.edgepoints)[:,0]
+        ylocs = np.array(self.edgepoints)[:,1]
+        left = np.argmin(xlocs)
+        right = np.argmax(xlocs)
+        top = np.argmax(ylocs)
+        bottom = np.argmin(ylocs)
+        edgepoints = np.array(self.edgepoints)
+        self.edgepoints = [edgepoints[left], edgepoints[top], edgepoints[right], edgepoints[bottom]]
 
 
     def browse_files(self):
@@ -503,7 +545,7 @@ class TrainingDataBrowser:
 
         frame_file = self.frame_name.get()
 
-        self.pupil_canvas.delete(self.pupil_plot)
+        #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.plot_frame(frame_file)
         self.master.mainloop()
 
@@ -540,7 +582,7 @@ class TrainingDataBrowser:
         new_frame_root = new_frame.split('.')[0]
         self.frame_name.insert(0, new_frame_root)
 
-        self.pupil_canvas.delete(self.pupil_plot)
+        #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.plot_frame(new_frame_root)
 
     def display_prev_frame(self):
@@ -572,9 +614,25 @@ class TrainingDataBrowser:
         new_frame_root = new_frame.split('.')[0]
         self.frame_name.insert(0, new_frame_root)
 
-        #self.pupil_canvas.delete(self.pupil_plot)
-        self.pupil_canvas.delete("all")
+        ##self.pupil_canvas.delete(self.pupil_plot)
+        #self.pupil_canvas.delete("all")
         self.pupil_plot = self.plot_frame(new_frame_root)
+
+
+def get_eyelid_keypoints(frame):
+    try:
+        lx = frame['ellipse_zack']['eyelid_left_x']
+        ly = frame['ellipse_zack']['eyelid_left_y']
+        tx = frame['ellipse_zack']['eyelid_top_x']
+        ty = frame['ellipse_zack']['eyelid_top_y']
+        rx = frame['ellipse_zack']['eyelid_right_x']
+        ry = frame['ellipse_zack']['eyelid_right_y']
+        bx = frame['ellipse_zack']['eyelid_bottom_x']
+        by = frame['ellipse_zack']['eyelid_bottom_y']
+        return [[lx, ly], [tx, ty], [rx, ry], [bx, by]]
+    except:
+        print("WARNING: Can't find labeled keypoints for eyelid. Make sure to label keypoints by clicking on corners of eyelids")
+        return [[np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan]]
 
 root = tk.Tk()
 
@@ -584,3 +642,4 @@ if len(sys.argv) > 1:
 else:
     my_gui = TrainingDataBrowser(root)
     root.mainloop()
+

--- a/nems_lbhb/pup_py/browse_training_data.py
+++ b/nems_lbhb/pup_py/browse_training_data.py
@@ -255,7 +255,7 @@ class TrainingDataBrowser:
         # save new ellipse params for this frame
         self.save_ellipse = tk.Button(master, text="Save new parameters", command=self.save_ellipse_params)
         self.save_ellipse.grid(row=10, column=1)
-
+    
         self.close_button = tk.Button(master, text="Close", command=self.close_browser)
         self.close_button.grid(row=10, column=0)
     

--- a/nems_lbhb/pup_py/browse_training_data.py
+++ b/nems_lbhb/pup_py/browse_training_data.py
@@ -536,18 +536,26 @@ class TrainingDataBrowser:
 
 
     def sort_edgepoints(self):
-        # helper function for sorting edgepoints so that the order is:
-        # 1 - left, 2 - top, 3 - right and 4 - bottom
-        # that way they're always in the same position for the fitter
+        # helper function for sorting edgepoints so that the order is
+        # based on the x position.
+        # that way they're (basically) always in the same position for the fitter,
+        # with the exception that the middle point can go high or low
+        # this is necessary (I think) because due to tilt, the y axis is ambiguous
+        # meaning, "top" isn't necessarily always higher than left / right
         # also, make sure they're not Nan (placeholders)
         if (len(self.edgepoints)!=4) | np.any(np.isnan(np.array(self.edgepoints))):
             raise ValueError("Must label all for edgepoints of the eyelid (left corner, middle-top, right corner, middle-bottom")
-        xlocs = np.array(self.edgepoints)[:,0]
-        ylocs = np.array(self.edgepoints)[:,1]
-        left = np.argmin(xlocs)
-        right = np.argmax(xlocs)
-        top = np.argmax(ylocs)
-        bottom = np.argmin(ylocs)
+        xlocs = np.array(edgepoints)[:,0]
+        sidx = np.argsort(xlocs)
+        left = sidx[0]
+        right = sidx[3]
+        top = sidx[1]
+        bottom = sidx[2]
+        if edgepoints[top][1]>edgepoints[bottom][1]:
+            pass
+        else:
+            top = sidx[2]
+            bottom = sidx[1]
         edgepoints = np.array(self.edgepoints)
         self.edgepoints = [edgepoints[left], edgepoints[top], edgepoints[right], edgepoints[bottom]]
 

--- a/nems_lbhb/pup_py/browse_training_data.py
+++ b/nems_lbhb/pup_py/browse_training_data.py
@@ -3,6 +3,7 @@ Script meant to be used for browsing saved training data and manually manipulati
 useful when you notice there is frame the must be manually annotated.
 '''
 import tkinter as tk
+from tkinter import filedialog, simpledialog, messagebox
 from matplotlib.backends import _backend_tk as tkagg
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 import os
@@ -29,6 +30,8 @@ class TrainingDataBrowser:
         # directory. If animal and video_name are specified, add 50 random frames from this video to the end of
         # the training directory and then display the first of these frames. if train_frame_range is not None, choose 
         # these 50 frames from this range. train frame range is tuple (start_frame, end_frame)
+
+        self.master = master
 
         self.plot_calls = 0
         self.edgepoints = []        
@@ -187,6 +190,8 @@ class TrainingDataBrowser:
         self.long_axis_value = tk.Entry(master)
         self.long_axis_value.grid(row=3, column=1)
         self.long_axis_value.focus_set()
+        self.long_axis_value.bind("<Button-4>", self.long_axis_scroll)
+        self.long_axis_value.bind("<Button-5>", self.long_axis_scroll)
         self.long_axis_ua = tk.Button(master, text=u"\u25B2", command=self.increase_la)
         self.long_axis_ua.grid(row=3, column=2)
         self.long_axis_da = tk.Button(master, text=u"\u25BC", command=self.decrease_la)
@@ -197,6 +202,8 @@ class TrainingDataBrowser:
         self.short_axis_value = tk.Entry(master)
         self.short_axis_value.grid(row=4, column=1)
         self.short_axis_value.focus_set()
+        self.short_axis_value.bind("<Button-4>", self.short_axis_scroll)
+        self.short_axis_value.bind("<Button-5>", self.short_axis_scroll)
         self.short_axis_ua = tk.Button(master, text=u"\u25B2", command=self.increase_sa)
         self.short_axis_ua.grid(row=4, column=2)
         self.short_axis_da = tk.Button(master, text=u"\u25BC", command=self.decrease_sa)
@@ -207,6 +214,8 @@ class TrainingDataBrowser:
         self.x_pos_value = tk.Entry(master)
         self.x_pos_value.grid(row=5, column=1)
         self.x_pos_value.focus_set()
+        self.x_pos_value.bind("<Button-4>", self.x_scroll)
+        self.x_pos_value.bind("<Button-5>", self.x_scroll)
         self.x_pos_ua = tk.Button(master, text=u"\u25B2", command=self.increase_x)
         self.x_pos_ua.grid(row=5, column=2)
         self.x_pos_da = tk.Button(master, text=u"\u25BC", command=self.decrease_x)
@@ -217,6 +226,8 @@ class TrainingDataBrowser:
         self.y_pos_value = tk.Entry(master)
         self.y_pos_value.grid(row=6, column=1)
         self.y_pos_value.focus_set()
+        self.y_pos_value.bind("<Button-4>", self.y_scroll)
+        self.y_pos_value.bind("<Button-5>", self.y_scroll)
         self.y_pos_ua = tk.Button(master, text=u"\u25B2", command=self.increase_y)
         self.y_pos_ua.grid(row=6, column=2)
         self.y_pos_da = tk.Button(master, text=u"\u25BC", command=self.decrease_y)
@@ -227,6 +238,8 @@ class TrainingDataBrowser:
         self.phi_value = tk.Entry(master)
         self.phi_value.grid(row=7, column=1)
         self.phi_value.focus_set()
+        self.phi_value.bind("<Button-4>", self.phi_scroll)
+        self.phi_value.bind("<Button-5>", self.phi_scroll)
         self.phi_ua = tk.Button(master, text=u"\u25B2", command=self.increase_phi)
         self.phi_ua.grid(row=7, column=2)
         self.phi_da = tk.Button(master, text=u"\u25BC", command=self.decrease_phi)
@@ -243,8 +256,20 @@ class TrainingDataBrowser:
         self.save_ellipse = tk.Button(master, text="Save new parameters", command=self.save_ellipse_params)
         self.save_ellipse.grid(row=10, column=1)
 
-        self.close_button = tk.Button(master, text="Close", command=master.destroy)
+        self.close_button = tk.Button(master, text="Close", command=self.close_browser)
         self.close_button.grid(row=10, column=0)
+    
+    def long_axis_scroll(self, event):
+        val = np.float(self.long_axis_value.get())
+        if event.num == 5 or event.delta == -120:
+            val -= 1
+        if event.num == 4 or event.delta == 120:
+            val += 1
+        self.long_axis_value.delete(0, 'end')
+        self.long_axis_value.insert(0, string=str(round(val, 2)))
+
+        #self.pupil_canvas.delete(self.pupil_plot)
+        self.pupil_plot = self.update_ellipse_plot()
 
     def increase_la(self):
         val = np.float(self.long_axis_value.get())
@@ -263,7 +288,19 @@ class TrainingDataBrowser:
 
         #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.update_ellipse_plot()
+    
+    def short_axis_scroll(self, event):
+        val = np.float(self.short_axis_value.get())
+        if event.num == 5 or event.delta == -120:
+            val -= 1
+        if event.num == 4 or event.delta == 120:
+            val += 1
+        self.short_axis_value.delete(0, 'end')
+        self.short_axis_value.insert(0, string=str(round(val, 2)))
 
+        #self.pupil_canvas.delete(self.pupil_plot)
+        self.pupil_plot = self.update_ellipse_plot()
+    
     def increase_sa(self):
         val = np.float(self.short_axis_value.get())
         val += 0.5
@@ -278,6 +315,18 @@ class TrainingDataBrowser:
         val -= 0.5
         self.short_axis_value.delete(0, 'end')
         self.short_axis_value.insert(0, string=str(round(val, 2)))
+
+        #self.pupil_canvas.delete(self.pupil_plot)
+        self.pupil_plot = self.update_ellipse_plot()
+
+    def x_scroll(self, event):
+        val = np.float(self.x_pos_value.get())
+        if event.num == 5 or event.delta == -120:
+            val -= 1
+        if event.num == 4 or event.delta == 120:
+            val += 1
+        self.x_pos_value.delete(0, 'end')
+        self.x_pos_value.insert(0, string=str(round(val, 2)))
 
         #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.update_ellipse_plot()
@@ -300,6 +349,18 @@ class TrainingDataBrowser:
         #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.update_ellipse_plot()
 
+    def y_scroll(self, event):
+        val = np.float(self.y_pos_value.get())
+        if event.num == 5 or event.delta == -120:
+            val -= 1
+        if event.num == 4 or event.delta == 120:
+            val += 1
+        self.y_pos_value.delete(0, 'end')
+        self.y_pos_value.insert(0, string=str(round(val, 2)))
+
+        #self.pupil_canvas.delete(self.pupil_plot)
+        self.pupil_plot = self.update_ellipse_plot()
+
     def increase_y(self):
         val = np.float(self.y_pos_value.get())
         val += 0.5
@@ -314,6 +375,18 @@ class TrainingDataBrowser:
         val -= 0.5
         self.y_pos_value.delete(0, 'end')
         self.y_pos_value.insert(0, string=str(round(val, 2)))
+
+        #self.pupil_canvas.delete(self.pupil_plot)
+        self.pupil_plot = self.update_ellipse_plot()
+
+    def phi_scroll(self, event):
+        val = np.float(self.phi_value.get())
+        if event.num == 5 or event.delta == -120:
+            val -= 1
+        if event.num == 4 or event.delta == 120:
+            val += 1
+        self.phi_value.delete(0, 'end')
+        self.phi_value.insert(0, string=str(round(val, 2)))
 
         #self.pupil_canvas.delete(self.pupil_plot)
         self.pupil_plot = self.update_ellipse_plot()
@@ -396,7 +469,6 @@ class TrainingDataBrowser:
         top = self.edgepoints[1]
         right = self.edgepoints[2]
         bottom = self.edgepoints[3]
-        print(self.edgepoints)
         e_params = {
             'X0_in': X0_in,
             'Y0_in': Y0_in,
@@ -544,7 +616,8 @@ class TrainingDataBrowser:
         # meaning, "top" isn't necessarily always higher than left / right
         # also, make sure they're not Nan (placeholders)
         if (len(self.edgepoints)!=4) | np.any(np.isnan(np.array(self.edgepoints))):
-            raise ValueError("Must label all for edgepoints of the eyelid (left corner, middle-top, right corner, middle-bottom")
+            messagebox.showerror("Error", "Must label all for edgepoints of the eyelid (left corner, middle-top, right corner, middle-bottom)")
+            raise ValueError
         xlocs = np.array(self.edgepoints)[:,0]
         sidx = np.argsort(xlocs)
         left = sidx[0]
@@ -639,7 +712,14 @@ class TrainingDataBrowser:
         ##self.pupil_canvas.delete(self.pupil_plot)
         #self.pupil_canvas.delete("all")
         self.pupil_plot = self.plot_frame(new_frame_root)
-
+    
+    def close_browser(self):
+        answer = answer = messagebox.askokcancel("Question", "STOP! Are all training frames labeled correctly?"
+                                        "If not, please go back and verify that all data is labeled correctly before closing the browser")
+        if answer:
+            self.master.destroy()
+        else:
+            pass
 
 def get_eyelid_keypoints(frame):
     try:

--- a/nems_lbhb/pup_py/browse_training_data.py
+++ b/nems_lbhb/pup_py/browse_training_data.py
@@ -89,22 +89,32 @@ class TrainingDataBrowser:
                 img2 = Image.open(tmp_save + video_name + '1' + '.jpg') #.convert('LA')
                 frame2 = np.asarray(img2)[:, :-10, 0]
                 output_dict['frame2'] = frame2  # for display purposes
-                output_dict['ellipse_zack'] = {
-                                'a': parms['cnn']['a'][f],
-                                'b': parms['cnn']['b'][f],  
-                                'X0_in': parms['cnn']['x'][f],
-                                'Y0_in': parms['cnn']['y'][f],
-                                'phi': parms['cnn']['phi'][f],
-                                'eyelid_left_x': parms['cnn']['eyelid_left_x'][f],
-                                'eyelid_left_y': parms['cnn']['eyelid_left_y'][f],
-                                'eyelid_top_x': parms['cnn']['eyelid_top_x'][f],
-                                'eyelid_top_y': parms['cnn']['eyelid_top_y'][f],
-                                'eyelid_right_x': parms['cnn']['eyelid_right_x'][f],
-                                'eyelid_right_y': parms['cnn']['eyelid_right_y'][f],
-                                'eyelid_bottom_x': parms['cnn']['eyelid_bottom_x'][f],
-                                'eyelid_bottom_y': parms['cnn']['eyelid_bottom_y'][f]
+                try:
+                    output_dict['ellipse_zack'] = {
+                                    'a': parms['cnn']['a'][f],
+                                    'b': parms['cnn']['b'][f],  
+                                    'X0_in': parms['cnn']['x'][f],
+                                    'Y0_in': parms['cnn']['y'][f],
+                                    'phi': parms['cnn']['phi'][f],
+                                    'eyelid_left_x': parms['cnn']['eyelid_left_x'][f],
+                                    'eyelid_left_y': parms['cnn']['eyelid_left_y'][f],
+                                    'eyelid_top_x': parms['cnn']['eyelid_top_x'][f],
+                                    'eyelid_top_y': parms['cnn']['eyelid_top_y'][f],
+                                    'eyelid_right_x': parms['cnn']['eyelid_right_x'][f],
+                                    'eyelid_right_y': parms['cnn']['eyelid_right_y'][f],
+                                    'eyelid_bottom_x': parms['cnn']['eyelid_bottom_x'][f],
+                                    'eyelid_bottom_y': parms['cnn']['eyelid_bottom_y'][f]
 
-                }
+                    }
+                except:
+                    output_dict['ellipse_zack'] = {
+                                    'a': parms['cnn']['a'][f],
+                                    'b': parms['cnn']['b'][f],  
+                                    'X0_in': parms['cnn']['x'][f],
+                                    'Y0_in': parms['cnn']['y'][f],
+                                    'phi': parms['cnn']['phi'][f],
+
+                    }
                 name = train_data_path + video_name + str(f) + '.pickle'
 
                 # if this frame isn't already in the training set, add it
@@ -418,6 +428,8 @@ class TrainingDataBrowser:
 
         print("saved new ellipse parameters for {0}".format(frame_file))
 
+        self.display_next_frame()
+
 
     def update_ellipse_plot(self):
         '''
@@ -633,7 +645,6 @@ def get_eyelid_keypoints(frame):
         by = frame['ellipse_zack']['eyelid_bottom_y']
         return [[lx, ly], [tx, ty], [rx, ry], [bx, by]]
     except:
-        import pdb; pdb.set_trace()
         print("WARNING: Can't find labeled keypoints for eyelid. Make sure to label keypoints by clicking on corners of eyelids")
         return [[np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan]]
 

--- a/nems_lbhb/pup_py/browse_training_data.py
+++ b/nems_lbhb/pup_py/browse_training_data.py
@@ -19,13 +19,14 @@ import nems_db
 nems_db_path = nems_db.__path__[0]
 sys.path.append(os.path.join(nems_db_path, 'nems_lbhb/pup_py/'))
 import pupil_settings as ps
-train_data_path = ps.TRAIN_DATA_PATH  #'/auto/data/nems_db/pup_py/training_data/'
-tmp_save = ps.TMP_SAVE                #'/auto/data/nems_db/pup_py/tmp/'
+#train_data_path = ps.TRAIN_DATA_PATH  #'/auto/data/nems_db/pup_py/training_data/'
+#tmp_save = ps.TMP_SAVE                #'/auto/data/nems_db/pup_py/tmp/'
+#temp_train_data_path = ps.TMP_TRAIN
+tmp_save = ps.TMP_SAVE                
 temp_train_data_path = ps.TMP_TRAIN
-
 class TrainingDataBrowser:
 
-    def __init__(self, master, animal=None, video_name=None, raw_video=None, min_frame=0, max_frame=5000, train_frame_range=None, n_frames=None):
+    def __init__(self, master, species='ferret', animal=None, video_name=None, raw_video=None, min_frame=0, max_frame=5000, train_frame_range=None, n_frames=None):
 
         # figure out which frames to display. If animal and video_name are none, display first frame from training
         # directory. If animal and video_name are specified, add 50 random frames from this video to the end of
@@ -33,12 +34,14 @@ class TrainingDataBrowser:
         # these 50 frames from this range. train frame range is tuple (start_frame, end_frame)
 
         self.master = master
+        # Default paths to ferret. Else, use species as directory
+        self.train_data_path = os.path.join(ps.ROOT_DIRECTORY, species, 'training_data/') 
 
         self.plot_calls = 0
         self.edgepoints = []        
         if (animal is None) and (video_name is None):
             self.from_browser = False
-            default_frame = os.listdir(train_data_path)[0].split('.')[0]
+            default_frame = os.listdir(self.train_data_path)[0].split('.')[0]
 
         else:
             # clear temp training directory
@@ -118,7 +121,7 @@ class TrainingDataBrowser:
                                     'phi': parms['cnn']['phi'][f],
 
                     }
-                name = train_data_path + video_name + str(f) + '.pickle'
+                name = self.train_data_path + video_name + str(f) + '.pickle'
 
 
                 # check to see if frame already exists in training directory. 
@@ -182,7 +185,7 @@ class TrainingDataBrowser:
         else:
             self.frame_count = tk.Text(master, height=1, width=12)
             self.frame_count.grid(row=0, column=2)
-            all_frames = os.listdir(train_data_path)
+            all_frames = os.listdir(self.train_data_path)
             self.frame_count.insert(tk.END, "1/{0}".format(len(all_frames)))
 
         self.frame_name = tk.Entry(master)
@@ -455,7 +458,7 @@ class TrainingDataBrowser:
             all_frames = os.listdir(temp_train_data_path)
             inds = np.argsort(np.array([int(''.join([s for s in x[9:] if s.isdigit()])) for x in all_frames]))
         else:
-            all_frames = os.listdir(train_data_path)
+            all_frames = os.listdir(self.train_data_path)
             inds = np.argsort(np.array([int(''.join([s for s in x[9:] if s.isdigit()])) for x in all_frames]))
 
         all_frames = np.array(all_frames)[inds]
@@ -464,7 +467,7 @@ class TrainingDataBrowser:
         prev_index = cur_index - 1
         prev_frame = all_frames[prev_index]
 
-        with open('{0}/{1}'.format(train_data_path, prev_frame), 'rb') as fp:
+        with open('{0}/{1}'.format(self.train_data_path, prev_frame), 'rb') as fp:
             prev_params = pickle.load(fp)
         
         self.update_ellipse_params(prev_params['ellipse_zack'])
@@ -507,7 +510,7 @@ class TrainingDataBrowser:
             with open('{0}/{1}.pickle'.format(temp_train_data_path, frame_file), 'rb') as fp:
                 current_params = pickle.load(fp)       
         else:
-            with open('{0}/{1}.pickle'.format(train_data_path, frame_file), 'rb') as fp:
+            with open('{0}/{1}.pickle'.format(self.train_data_path, frame_file), 'rb') as fp:
                 current_params = pickle.load(fp)
 
         new_params = current_params.copy()
@@ -515,7 +518,7 @@ class TrainingDataBrowser:
         # which served as first training data for this.
         new_params['ellipse_zack'] = e_params
 
-        with open(train_data_path+'{0}.pickle'.format(frame_file), 'wb') as fp:
+        with open(self.train_data_path+'{0}.pickle'.format(frame_file), 'wb') as fp:
             pickle.dump(new_params, fp, protocol=pickle.HIGHEST_PROTOCOL)
         
         # also update temp params
@@ -539,7 +542,7 @@ class TrainingDataBrowser:
             with open('{0}/{1}.pickle'.format(temp_train_data_path, frame_file), 'rb') as fp:
                 frame_data = pickle.load(fp)
         else:
-            with open('{0}/{1}.pickle'.format(train_data_path, frame_file), 'rb') as fp:
+            with open('{0}/{1}.pickle'.format(self.train_data_path, frame_file), 'rb') as fp:
                 frame_data = pickle.load(fp)
 
         loc = (0, 0)
@@ -577,7 +580,7 @@ class TrainingDataBrowser:
                 frame_data = pickle.load(fp)
                 fp.close()
         else:
-            with open('{0}/{1}.pickle'.format(train_data_path, frame_file), 'rb') as fp:
+            with open('{0}/{1}.pickle'.format(self.train_data_path, frame_file), 'rb') as fp:
                 frame_data = pickle.load(fp)
                 fp.close()
 
@@ -689,7 +692,7 @@ class TrainingDataBrowser:
             all_frames = os.listdir(temp_train_data_path)
             inds = np.argsort(np.array([int(''.join([s for s in x[9:] if s.isdigit()])) for x in all_frames]))
         else:
-            all_frames = os.listdir(train_data_path)
+            all_frames = os.listdir(self.train_data_path)
             inds = np.argsort(np.array([int(''.join([s for s in x[9:] if s.isdigit()])) for x in all_frames]))
 
         all_frames = np.array(all_frames)[inds]
@@ -723,7 +726,7 @@ class TrainingDataBrowser:
             all_frames = os.listdir(temp_train_data_path)
             inds = np.argsort(np.array([int(''.join([s for s in x[9:] if s.isdigit()])) for x in all_frames]))
         else:
-            all_frames = os.listdir(train_data_path)
+            all_frames = os.listdir(self.train_data_path)
             inds = np.argsort(np.array([int(''.join([s for s in x[9:] if s.isdigit()])) for x in all_frames]))
         all_frames = np.array(all_frames)[inds]
 
@@ -772,7 +775,7 @@ def get_eyelid_keypoints(frame):
 root = tk.Tk()
 
 if len(sys.argv) > 1:
-    my_gui = TrainingDataBrowser(root, sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5], sys.argv[6], sys.argv[7])
+    my_gui = TrainingDataBrowser(root, sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5], sys.argv[6], sys.argv[7], sys.argv[8])
     root.mainloop()
 else:
     my_gui = TrainingDataBrowser(root)

--- a/nems_lbhb/pup_py/browse_training_data.py
+++ b/nems_lbhb/pup_py/browse_training_data.py
@@ -545,13 +545,13 @@ class TrainingDataBrowser:
         # also, make sure they're not Nan (placeholders)
         if (len(self.edgepoints)!=4) | np.any(np.isnan(np.array(self.edgepoints))):
             raise ValueError("Must label all for edgepoints of the eyelid (left corner, middle-top, right corner, middle-bottom")
-        xlocs = np.array(edgepoints)[:,0]
+        xlocs = np.array(self.edgepoints)[:,0]
         sidx = np.argsort(xlocs)
         left = sidx[0]
         right = sidx[3]
         top = sidx[1]
         bottom = sidx[2]
-        if edgepoints[top][1]>edgepoints[bottom][1]:
+        if self.edgepoints[top][1]>self.edgepoints[bottom][1]:
             pass
         else:
             top = sidx[2]

--- a/nems_lbhb/pup_py/browse_training_data.py
+++ b/nems_lbhb/pup_py/browse_training_data.py
@@ -453,10 +453,10 @@ class TrainingDataBrowser:
 
         if self.from_browser:
             all_frames = os.listdir(temp_train_data_path)
-            inds = np.argsort(np.array([int(x[15:].strip('.pickle')) for x in all_frames]))
+            inds = np.argsort(np.array([int(''.join([s for s in x[9:] if s.isdigit()])) for x in all_frames]))
         else:
             all_frames = os.listdir(train_data_path)
-            inds = np.argsort(np.array([int(x[15:].strip('.pickle')) for x in all_frames]))
+            inds = np.argsort(np.array([int(''.join([s for s in x[9:] if s.isdigit()])) for x in all_frames]))
 
         all_frames = np.array(all_frames)[inds]
 
@@ -685,13 +685,12 @@ class TrainingDataBrowser:
         '''
 
         current_frame = self.frame_name.get()
-
         if self.from_browser:
             all_frames = os.listdir(temp_train_data_path)
-            inds = np.argsort(np.array([int(x[15:].strip('.pickle')) for x in all_frames]))
+            inds = np.argsort(np.array([int(''.join([s for s in x[9:] if s.isdigit()])) for x in all_frames]))
         else:
             all_frames = os.listdir(train_data_path)
-            inds = np.argsort(np.array([int(x[15:].strip('.pickle')) for x in all_frames]))
+            inds = np.argsort(np.array([int(''.join([s for s in x[9:] if s.isdigit()])) for x in all_frames]))
 
         all_frames = np.array(all_frames)[inds]
 
@@ -722,10 +721,10 @@ class TrainingDataBrowser:
         current_frame = self.frame_name.get()
         if self.from_browser:
             all_frames = os.listdir(temp_train_data_path)
-            inds = np.argsort(np.array([int(x[15:].strip('.pickle')) for x in all_frames]))
+            inds = np.argsort(np.array([int(''.join([s for s in x[9:] if s.isdigit()])) for x in all_frames]))
         else:
             all_frames = os.listdir(train_data_path)
-            inds = np.argsort(np.array([int(x[15:].strip('.pickle')) for x in all_frames]))
+            inds = np.argsort(np.array([int(''.join([s for s in x[9:] if s.isdigit()])) for x in all_frames]))
         all_frames = np.array(all_frames)[inds]
 
         cur_index = np.argwhere(all_frames == current_frame + '.pickle')[0][0]

--- a/nems_lbhb/pup_py/fit_pupil.py
+++ b/nems_lbhb/pup_py/fit_pupil.py
@@ -9,19 +9,22 @@ import nems.db as nd
 import getpass
 from tkinter import filedialog, messagebox
 
+import nems_db
 import sys
 import os
-import nems_db
 executable_path = sys.executable
 script_path = os.path.split(os.path.split(nems_db.__file__)[0])[0]
 script_path = os.path.join(script_path, 'nems_lbhb', 'pup_py', 'pupil_fit_script.py')
+nems_db_path = nems_db.__path__[0]
+sys.path.append(os.path.join(nems_db_path, 'nems_lbhb/pup_py/'))
+import pupil_settings as ps
 
 class queue_pupil_job:
 
     def __init__(self, master):
         self.master = master
         master.title("Queue pupil job")
-        master.geometry('400x150')
+        master.geometry('700x175')
 
         self.filename = tk.Label(master, text="Filename: ")
         self.filename.grid(row=1, column=0)
@@ -40,30 +43,39 @@ class queue_pupil_job:
         self.fitDate_value.focus_set()
         self.fitDate_value.insert(0, "Current")
 
+        self.species_label = tk.Label(master, text="Species: ")
+        self.species_label.grid(row=3, column=0)
+        self.species = tk.StringVar(master)
+        self.species.set('ferret') # default value
+        options = os.listdir(ps.ROOT_DIRECTORY)
+        self.species_dd = tk.OptionMenu(master, self.species, *options)
+        self.species_dd.grid(row=3, column=1, sticky='ew')
+        self.species_dd.focus_set()
+
 
         self.animal_fit = tk.Label(master, text="Animal: ")
-        self.animal_fit.grid(row=3, column=0)
+        self.animal_fit.grid(row=4, column=0)
         self.animal_fit_value = tk.Entry(master)
-        self.animal_fit_value.grid(row=3, column=1, sticky='ew')
+        self.animal_fit_value.grid(row=4, column=1, sticky='ew')
         self.animal_fit_value.focus_set()
         self.animal_fit_value.insert(0, "All")
 
         self.executable_path = tk.Label(master, text="Python path: ")
-        self.executable_path.grid(row=4, column=0)
+        self.executable_path.grid(row=5, column=0)
         self.executable_path_value = tk.Entry(master)
-        self.executable_path_value.grid(row=4, column=1, sticky='ew')
+        self.executable_path_value.grid(row=5, column=1, sticky='ew')
         self.executable_path_value.focus_set()
         self.executable_path_value.insert(0, executable_path)
 
         self.script_path = tk.Label(master, text="Fit script: ")
-        self.script_path.grid(row=5, column=0)
+        self.script_path.grid(row=6, column=0)
         self.script_path_value = tk.Entry(master)
-        self.script_path_value.grid(row=5, column=1, sticky='ew')
+        self.script_path_value.grid(row=6, column=1, sticky='ew')
         self.script_path_value.focus_set()
         self.script_path_value.insert(0, script_path)
 
         self.fit_button = tk.Button(master, text="Start fit", command=self.start_fit)
-        self.fit_button.grid(row=6, column=0)
+        self.fit_button.grid(row=7, column=0)
 
         master.grid_columnconfigure(1, weight=1)
 
@@ -74,6 +86,7 @@ class queue_pupil_job:
         fn = self.video_file
         modeldate = self.fitDate_value.get()
         animal = self.animal_fit_value.get()
+        species = self.species.get()
         answer = True
         if (animal != '') & (animal != 'All') & (animal != 'all'):
             answer = messagebox.askokcancel("Question", "You've asked to fit this video using the model architecture that was overfit"
@@ -88,7 +101,7 @@ class queue_pupil_job:
 
         # add job to queue
         if answer:
-            nd.add_job_to_queue([fn, modeldate, animal], note="Pupil Job: {}".format(fn),
+            nd.add_job_to_queue([fn, modeldate, f"{species}_{animal}"], note="Pupil Job: {}".format(fn),
                                 executable_path=py_path, user=username,
                                 force_rerun=True, script_path=script_path, GPU_job=1)
             print("added job to queue")

--- a/nems_lbhb/pup_py/keras_classes.py
+++ b/nems_lbhb/pup_py/keras_classes.py
@@ -51,7 +51,17 @@ class DataGenerator(keras.utils.Sequence):
             long_axis = current_frame['ellipse_zack']['b'] * 2
             short_axis = current_frame['ellipse_zack']['a'] * 2
             phi = current_frame['ellipse_zack']['phi']
-            y[i, :] = np.asarray([Y0_in, X0_in, long_axis, short_axis, phi])
+            # eyelid keypoints
+            lx = current_frame['ellipse_zack']['eyelid_left_x']
+            ly = current_frame['ellipse_zack']['eyelid_left_y']
+            tx = current_frame['ellipse_zack']['eyelid_top_x']
+            ty = current_frame['ellipse_zack']['eyelid_top_y']
+            rx = current_frame['ellipse_zack']['eyelid_right_x']
+            ry = current_frame['ellipse_zack']['eyelid_right_y']
+            bx = current_frame['ellipse_zack']['eyelid_bottom_x']
+            by = current_frame['ellipse_zack']['eyelid_bottom_y']
+            y[i, :] = np.asarray([Y0_in, X0_in, long_axis, short_axis, phi,
+                            lx, ly, tx, ty, rx, ry, bx, by])
 
             if self.augment:
                 # randomly augment mini-batches by performing transformations on each image
@@ -63,7 +73,16 @@ class DataGenerator(keras.utils.Sequence):
                 scale_fact, im = ut.resize(current_frame['frame'], size=self.image_dim)
 
             y[i, ] = np.asarray([y[i, 0] * scale_fact[1], y[i, 1] * scale_fact[0], y[i, 2] * scale_fact[1],
-                                y[i, 3] * scale_fact[0], y[i, 4]])
+                                y[i, 3] * scale_fact[0], y[i, 4],
+                                y[i, 5] * scale_fact[0],
+                                y[i, 6] * scale_fact[1],
+                                y[i, 7] * scale_fact[0],
+                                y[i, 8] * scale_fact[1],
+                                y[i, 9] * scale_fact[0],
+                                y[i, 10] * scale_fact[1],
+                                y[i, 11] * scale_fact[0],
+                                y[i, 12] * scale_fact[1],
+                                ])
 
             im = keras.applications.densenet.preprocess_input(im)
 
@@ -74,6 +93,7 @@ class DataGenerator(keras.utils.Sequence):
             y[i, 2] = y[i, 2] / (self.image_dim[1] / 2)
             y[i, 3] = y[i, 3] / (self.image_dim[1] / 2)
             y[i, 4] = (y[i, 4] / (np.pi)) 
+            y[i, 5:] = y[i, 5:] / self.image_dim[1]
 
             y[i, :] = y[i, :] * 100
             

--- a/nems_lbhb/pup_py/keras_classes.py
+++ b/nems_lbhb/pup_py/keras_classes.py
@@ -10,14 +10,15 @@ import sys
 sys.path.append(os.path.join(nems_db_path, 'nems_lbhb/pup_py/'))
 import pupil_settings as ps
 
+from batch_norm import NORM_FACTORS
+
 # define global variables for data
 path = ps.TRAIN_DATA_PATH  #'/auto/data/nems_db/pup_py/training_data/'
 data_frames = os.listdir(path)
 
-
 class DataGenerator(keras.utils.Sequence):
 
-    def __init__(self, list_IDs, batch_size=32, image_dim=(224, 224), n_parms=5, n_channels=3, shuffle=True,
+    def __init__(self, list_IDs, batch_size=32, image_dim=(224, 224), n_parms=13, n_channels=3, shuffle=True,
                  augment_minibatches=False):
         self.batch_size = batch_size
         self.list_IDs = list_IDs
@@ -88,6 +89,11 @@ class DataGenerator(keras.utils.Sequence):
 
             # this stuff is still a WIP. Trying to normalize parameters for the fit so one isn't weighted more heavily than others            
             # normalize the params to live between 0 and 1
+            for j, (_, v) in enumerate(NORM_FACTORS.items()):
+                # these should be sorted in the same order as y, so no need to use the
+                # dict keys in NORM_FACTORS
+                y[i, j] = (y[i, j] / v[2]) #/ v[1]
+            '''
             y[i, 0] = y[i, 0] / self.image_dim[1]
             y[i, 1] = y[i, 1] / self.image_dim[1]
             y[i, 2] = y[i, 2] / (self.image_dim[1] / 2)
@@ -96,7 +102,7 @@ class DataGenerator(keras.utils.Sequence):
             y[i, 5:] = y[i, 5:] / self.image_dim[1]
 
             y[i, :] = y[i, :] * 100
-            
+            '''
             X[i, ] = np.tile(np.expand_dims(im, -1), [1, 1, 3])
 
         return X, y

--- a/nems_lbhb/pup_py/keras_classes.py
+++ b/nems_lbhb/pup_py/keras_classes.py
@@ -100,9 +100,9 @@ class DataGenerator(keras.utils.Sequence):
             y[i, 3] = y[i, 3] / (self.image_dim[1] / 2)
             y[i, 4] = (y[i, 4] / (np.pi)) 
             y[i, 5:] = y[i, 5:] / self.image_dim[1]
-
-            y[i, :] = y[i, :] * 100
             '''
+            y[i, :] = y[i, :] * 100
+            
             X[i, ] = np.tile(np.expand_dims(im, -1), [1, 1, 3])
 
         return X, y

--- a/nems_lbhb/pup_py/keras_classes.py
+++ b/nems_lbhb/pup_py/keras_classes.py
@@ -10,16 +10,16 @@ import sys
 sys.path.append(os.path.join(nems_db_path, 'nems_lbhb/pup_py/'))
 import pupil_settings as ps
 
-from batch_norm import NORM_FACTORS
+from batch_norm import get_batch_norm_params
 
 # define global variables for data
-path = ps.TRAIN_DATA_PATH  #'/auto/data/nems_db/pup_py/training_data/'
-data_frames = os.listdir(path)
+#path = ps.TRAIN_DATA_PATH  #'/auto/data/nems_db/pup_py/training_data/'
+#data_frames = os.listdir(path)
 
 class DataGenerator(keras.utils.Sequence):
 
     def __init__(self, list_IDs, batch_size=32, image_dim=(224, 224), n_parms=13, n_channels=3, shuffle=True,
-                 augment_minibatches=False):
+                 augment_minibatches=False, species='ferret'):
         self.batch_size = batch_size
         self.list_IDs = list_IDs
         self.n_parms = n_parms
@@ -28,6 +28,10 @@ class DataGenerator(keras.utils.Sequence):
         self.shuffle = shuffle
         self.augment = augment_minibatches
         self.on_epoch_end()
+        global NORM_FACTORS, data_frames, path
+        NORM_FACTORS = get_batch_norm_params(species)
+        path = os.path.join(ps.ROOT_DIRECTORY, species, 'training_data/')  #'/auto/data/nems_db/pup_py/training_data/'
+        data_frames = os.listdir(path)
 
     def on_epoch_end(self):
         'Update index after each epoch'

--- a/nems_lbhb/pup_py/plot_training_data_params.py
+++ b/nems_lbhb/pup_py/plot_training_data_params.py
@@ -23,7 +23,7 @@ for i, f in enumerate(training_files):
     sf, im = ut.resize(d['frame'], size=(224, 224))
     par = d['ellipse_zack']
     params[i, :] = [par['X0_in'] * sf[0], par['Y0_in'] * sf[1], par['b'] * sf[1], par['a'] * sf[0], par['phi']]
-
+PARMS = params
 
 f, ax = plt.subplots(1, 1, figsize=(8, 4))
 

--- a/nems_lbhb/pup_py/pupil_browser.py
+++ b/nems_lbhb/pup_py/pupil_browser.py
@@ -278,8 +278,8 @@ class PupilBrowser:
             except:
                 pass
 
-        self.top_eyelid_plot = self.eye_movement_ax.plot(top, 'tab:orange')
-        self.bottom_eyelid_plot = self.eye_movement_ax.plot(bottom, color='tab:blue')
+        self.top_plot = self.eye_movement_ax.plot(top, 'tab:orange')
+        self.bottom_plot = self.eye_movement_ax.plot(bottom, color='tab:blue')
         self.eye_movement_ax.set_ylim((np.nanmin([np.nanmin(top), np.nanmin(bottom)]),
                          np.nanmax([np.nanmax(top), np.nanmax(bottom)])))
         self.eye_movement_ax.set_xlim((0, len(top)))

--- a/nems_lbhb/pup_py/pupil_browser.py
+++ b/nems_lbhb/pup_py/pupil_browser.py
@@ -271,13 +271,18 @@ class PupilBrowser:
             except:
                 pass
 
-        self.top_plot = self.eye_movement_ax.plot(top, 'tab:orange', label='top eyelid')
+        self.top_plot = self.eye_movement_ax.plot(top, 'tab:orange', label='top eyelid', picker=5)
         self.bottom_plot = self.eye_movement_ax.plot(bottom, color='tab:blue', label='bottom eyelid')
         self.eye_movement_ax.set_ylim((np.nanmin([np.nanmin(top), np.nanmin(bottom)]),
                          np.nanmax([np.nanmax(top), np.nanmax(bottom)])))
         self.eye_movement_ax.set_xlim((0, len(top)))
 
         self.eye_movement_ax.legend(bbox_to_anchor=(1,1), loc='upper left', frameon=False)
+
+        canvas.get_tk_widget().focus_force()
+        canvas.mpl_connect('key_press_event', self.on_key)
+        canvas.mpl_connect('pick_event', self.get_coords)
+        canvas.mpl_connect('key_release_event', self.off_key)
 
         canvas.draw()
 
@@ -364,7 +369,7 @@ class PupilBrowser:
                 else:
                     self.hline2_end = self.eye_movement_ax.axvline(int(event.mouseevent.xdata),
                                                  color='red')
-                    mi, ma = self.ax.get_ylim()
+                    mi, ma = self.eye_movement_ax.get_ylim()
                     mi = int(mi)
                     ma = int(ma)+1
                     self.end_val = int(event.mouseevent.xdata)
@@ -410,7 +415,7 @@ class PupilBrowser:
                 if self.end_val not in self.exclude_ends:
                     self.exclude_ends.append(self.end_val)    
 
-                self.plot_trace(self.video_name.get(), exclude=True)
+                self.plot_eyelid_movement(self.video_name.get(), exclude=True)
             else:
                 pass
         elif event.key=='escape':

--- a/nems_lbhb/pup_py/pupil_browser.py
+++ b/nems_lbhb/pup_py/pupil_browser.py
@@ -164,9 +164,26 @@ class PupilBrowser:
         x = self.parms['cnn']['x'][fn]
         y = self.parms['cnn']['y'][fn]
         phi = self.parms['cnn']['phi'][fn]
+        try:
+            edgepoints = [
+                        [self.parms['cnn']['eyelid_left_x'][fn], self.parms['cnn']['eyelid_left_y'][fn]],
+                        [self.parms['cnn']['eyelid_top_x'][fn], self.parms['cnn']['eyelid_top_y'][fn]],
+                        [self.parms['cnn']['eyelid_right_x'][fn], self.parms['cnn']['eyelid_right_y'][fn]],
+                        [self.parms['cnn']['eyelid_bottom_x'][fn], self.parms['cnn']['eyelid_bottom_y'][fn]],
+            ]
+        except:
+            # for backwards compatibility with fits that don't have eyelid keypoints
+            edgepoints = None
 
         ellipse = Ellipse((y, x), b * 2, - a * 2, 180 * phi / np.pi, fill=False, color='red')
         ax.add_patch(ellipse)
+
+        if edgepoints is None:
+            print("Old model fit. Doesn't have eyelide keypoint detection")
+        else:
+            ax.plot(np.array(edgepoints)[:, 0],
+                                    np.array(edgepoints)[:, 1], lw=0, marker='o', markersize=5, color='red')
+
         ax.axis('off')
 
         figure_canvas_agg = FigureCanvasTkAgg(figure, master=self.master)

--- a/nems_lbhb/pup_py/pupil_browser.py
+++ b/nems_lbhb/pup_py/pupil_browser.py
@@ -624,9 +624,24 @@ class PupilBrowser:
         script_path = os.path.join(script_path, 'nems_lbhb', 'pup_py', 'training_script.py')
         username = getpass.getuser()
 
+        default_epochs = 500
+        n_training_epochs = simpledialog.askstring('TrainingEpochs', 'How many training epochs would you like to use? Default is 500')
+        try:
+            n_training_epochs = int(n_training_epochs)
+            print(f"using {n_training_epochs} training epochs")
+        except:
+            print("using default -- 500 training epochs")
+            n_training_epochs = default_epochs
+
         # add job to queue
-        nd.add_job_to_queue([], note="Pupil Job: Training CNN", executable_path=py_path,
-                            user=username, force_rerun=True, script_path=script_path, GPU_job=1)
+        # nd.add_job_to_queue([], note="Pupil Job: Training CNN", executable_path=py_path,
+        #                    user=username, force_rerun=True, script_path=script_path, GPU_job=1)
+        import datetime
+        date = str(datetime.datetime.now())
+        nd.enqueue_single_model(cellid='PupilTrainingJob', batch=n_training_epochs, modelname=date, 
+                                user=username, force_rerun=True, script_path=script_path, 
+                                executable_path=py_path, GPU_job=1)
+        
         print("Queueing new model training. Check status on queue. When finished, re-fit the pupil for this recording")
         # self.master.destroy
 
@@ -636,6 +651,7 @@ class PupilBrowser:
         # data from this animal in the database.
         # This will lead to a model that is *likely* very over-fit to this particular animal. So, you should 
         # really only use this if nothing else is working for you.
+        raise DeprecationWarning("This never seemed to work well. Should probably be purged.")
         py_path = sys.executable
         script_path = os.path.split(os.path.split(nems_db.__file__)[0])[0]
         script_path = os.path.join(script_path, 'nems_lbhb', 'pup_py', 'training_script.py')

--- a/nems_lbhb/pup_py/pupil_browser.py
+++ b/nems_lbhb/pup_py/pupil_browser.py
@@ -235,13 +235,13 @@ class PupilBrowser:
             except:
                 pass
 
-        self.a_plot = self.ax.plot(a, 'r')
-        self.b_plot = self.ax.plot(b, color='b', picker=5)
+        self.a_plot = self.ax.plot(a, 'r', label='minor axis')
+        self.b_plot = self.ax.plot(b, color='b', picker=5, label='major axis')
         self.ax.set_ylim((np.nanmin([np.nanmin(a), np.nanmin(b)]),
                          np.nanmax([np.nanmax(a), np.nanmax(b)])))
         self.ax.set_xlim((0, len(a)))
 
-        self.ax.legend(['minor axis', 'major axis'], bbox_to_anchor=(1,1), loc='upper left', frameon=False)
+        self.ax.legend(bbox_to_anchor=(1,1), loc='upper left', frameon=False)
 
         canvas.get_tk_widget().focus_force()
         canvas.mpl_connect('key_press_event', self.on_key)
@@ -271,13 +271,13 @@ class PupilBrowser:
             except:
                 pass
 
-        self.top_plot = self.eye_movement_ax.plot(top, 'tab:orange')
-        self.bottom_plot = self.eye_movement_ax.plot(bottom, color='tab:blue')
+        self.top_plot = self.eye_movement_ax.plot(top, 'tab:orange', label='top eyelid')
+        self.bottom_plot = self.eye_movement_ax.plot(bottom, color='tab:blue', label='bottom eyelid')
         self.eye_movement_ax.set_ylim((np.nanmin([np.nanmin(top), np.nanmin(bottom)]),
                          np.nanmax([np.nanmax(top), np.nanmax(bottom)])))
         self.eye_movement_ax.set_xlim((0, len(top)))
 
-        self.eye_movement_ax.legend(['bottom eyelid', 'top eyelid'], bbox_to_anchor=(1,1), loc='upper left', frameon=False)
+        self.eye_movement_ax.legend(bbox_to_anchor=(1,1), loc='upper left', frameon=False)
 
         canvas.draw()
 
@@ -477,7 +477,7 @@ class PupilBrowser:
         try:
             self.plot_eyelid_movement(params_file)
         except:
-            log.info("Couldn't load eyelid keypoints -- old fit?")
+            print("Couldn't load eyelid keypoints -- old fit?")
             pass
         self.frame_n_value.insert(0, str(0))
 

--- a/nems_lbhb/pup_py/pupil_browser.py
+++ b/nems_lbhb/pup_py/pupil_browser.py
@@ -497,6 +497,9 @@ class PupilBrowser:
 
         frame_file = tmp_frame_folder + 'frame1.jpg'
 
+        # define the species for this animal by querying the database
+        self.species = nd.pd_query(f"SELECT species from gAnimal where animal='{self.animal_name.get()}'").values[0][0]
+
         self.plot_frame(frame_file)
         self.master.mainloop()
 
@@ -605,8 +608,8 @@ class PupilBrowser:
                                  parent=self.master,
                                  minvalue=0, maxvalue=100)
             os.system("{0} \
-                {1} {2} {3} {4} {5} {6} {7} {8}".format(executable_path, training_browser_path,
-            self.animal_name.get(), self.video_name.get(), self.raw_video, 0, self.max_frame, frame_range, int(n_frames)))
+                {1} {2} {3} {4} {5} {6} {7} {8} {9}".format(executable_path, training_browser_path,
+            self.species, self.animal_name.get(), self.video_name.get(), self.raw_video, 0, self.max_frame, frame_range, int(n_frames)))
 
             # clear selection so that you can choose for frames, if desired.
             self.exclude_ends = []
@@ -638,7 +641,7 @@ class PupilBrowser:
         #                    user=username, force_rerun=True, script_path=script_path, GPU_job=1)
         import datetime
         date = str(datetime.datetime.now())
-        nd.enqueue_single_model(cellid='PupilTrainingJob', batch=n_training_epochs, modelname=date, 
+        nd.enqueue_single_model(cellid=f'PupilTrainingJob_{self.species}', batch=n_training_epochs, modelname=date, 
                                 user=username, force_rerun=True, script_path=script_path, 
                                 executable_path=py_path, GPU_job=1)
         

--- a/nems_lbhb/pup_py/pupil_fit_script.py
+++ b/nems_lbhb/pup_py/pupil_fit_script.py
@@ -92,6 +92,7 @@ if __name__ == '__main__':
     x_cnn = []
     y_cnn = []
     phi_cnn = []
+    lx=[];ly=[];tx=[];ty=[];rx=[];ry=[];bx=[];by=[];
 
     # reopen the video with pyav
     container = av.open(video)
@@ -132,6 +133,7 @@ if __name__ == '__main__':
             ellipse_parms[3] = ellipse_parms[3] * (size[0] / 2)
 
             ellipse_parms[4] = ellipse_parms[4] * np.pi
+            ellipse_parms[5:] = ellipse_parms[5:] * size[0] # eyelid keypoints
 
             # undo scaling and save
             y_cnn.append(ellipse_parms[0] / sf[1])
@@ -139,7 +141,14 @@ if __name__ == '__main__':
             b_cnn.append(ellipse_parms[2] / sf[1] / 2)
             a_cnn.append(ellipse_parms[3] / sf[0] / 2)
             phi_cnn.append(ellipse_parms[4])
-
+            lx.append(ellipse_parms[5] / sf[0])
+            ly.append(ellipse_parms[6] / sf[1])
+            tx.append(ellipse_parms[7] / sf[0])
+            ty.append(ellipse_parms[8] / sf[1])
+            rx.append(ellipse_parms[9] / sf[0])
+            ry.append(ellipse_parms[10] / sf[1])
+            bx.append(ellipse_parms[11] / sf[0])
+            by.append(ellipse_parms[12] / sf[1])
         except:
             log.info("video decoding failed for frame {0}. Frame dropped? Pad with nans for now...".format(i))
 
@@ -148,7 +157,14 @@ if __name__ == '__main__':
             b_cnn.append(np.nan)
             a_cnn.append(np.nan)
             phi_cnn.append(np.nan)
-
+            lx.append(np.nan)
+            ly.append(np.nan)
+            tx.append(np.nan)
+            ty.append(np.nan)
+            rx.append(np.nan)
+            ry.append(np.nan)
+            bx.append(np.nan)
+            by.append(np.nan)
     results = {
         'cnn': {
             'a': np.array(a_cnn),
@@ -156,6 +172,14 @@ if __name__ == '__main__':
             'x': np.array(x_cnn),
             'y': np.array(y_cnn),
             'phi': np.array(phi_cnn)
+            'eyelid_left_x': lx,
+            'eyelid_left_y': ly,
+            'eyelid_top_x': tx,
+            'eyelid_top_y': ty,
+            'eyelid_right_x': rx,
+            'eyelid_right_y': ry,
+            'eyelid_bottom_x': bx,
+            'eyelid_bottom_y': by,
         },
         'cnn_modelpath': modelpath
     }

--- a/nems_lbhb/pup_py/pupil_fit_script.py
+++ b/nems_lbhb/pup_py/pupil_fit_script.py
@@ -131,6 +131,7 @@ if __name__ == '__main__':
                 # these should be sorted in the same order as y, so no need to use the
                 # dict keys in NORM_FACTORS
                 ellipse_parms[j] = (ellipse_parms[j] * v[2]) #+ v[0]
+            ellipse_parms /= 100
             '''
             ellipse_parms /= 100
             ellipse_parms[0] = ellipse_parms[0] * size[0]

--- a/nems_lbhb/pup_py/pupil_fit_script.py
+++ b/nems_lbhb/pup_py/pupil_fit_script.py
@@ -51,9 +51,8 @@ if __name__ == '__main__':
     modelname = sys.argv[2]
     animal = sys.argv[3]
 
-    # load the keras model (this is hardcoded rn but should be flexible at some point
-    #model = keras.models.load_model('/auto/data/nems_db/pup_py/default_trained_model.hdf5')
-    project_dir = ps.ROOT_DIRECTORY  #'/auto/data/nems_db/pup_py/'
+    # load the keras model 
+    project_dir = ps.ROOT_DIRECTORY 
     if (modelname == 'current') | (modelname == 'Current'):
         if (animal != '') & (animal != 'None') & (animal != 'All') & (animal != None):
             this_model_dir = 'animal_specific_fits/{}/'.format(animal)
@@ -65,6 +64,8 @@ if __name__ == '__main__':
             name = os.listdir(project_dir + 'default_trained_model/{0}'.format(default_date))[0]
             modelpath = project_dir + 'default_trained_model/{0}/{1}'.format(default_date, name)
     else:
+        # load an older model fit for this pupil video. Probably not used often, but nice 
+        # to have the option...
         date = modelname
         datefolder = os.listdir(project_dir + 'old_model_fits/' + date)
         modelname = [m for m in datefolder if 'weights' in m][0]

--- a/nems_lbhb/pup_py/pupil_fit_script.py
+++ b/nems_lbhb/pup_py/pupil_fit_script.py
@@ -19,7 +19,7 @@ import nems_db
 nems_db_path = nems_db.__path__[0]
 sys.path.append(os.path.join(nems_db_path, 'nems_lbhb/pup_py/'))
 import pupil_settings as ps
-from batch_norm import NORM_FACTORS
+from batch_norm import get_batch_norm_params
 
 import logging
 log = logging.getLogger(__name__)
@@ -50,10 +50,10 @@ if __name__ == '__main__':
     # perform pupil fit
     video_file = sys.argv[1]
     modelname = sys.argv[2]
-    animal = sys.argv[3]
+    species, animal = sys.argv[3].split('_')
 
     # load the keras model 
-    project_dir = ps.ROOT_DIRECTORY 
+    project_dir = os.path.join(ps.ROOT_DIRECTORY, species+'/') 
     if (modelname == 'current') | (modelname == 'Current'):
         if (animal != '') & (animal != 'None') & (animal != 'All') & (animal != None):
             this_model_dir = 'animal_specific_fits/{}/'.format(animal)
@@ -71,6 +71,8 @@ if __name__ == '__main__':
         datefolder = os.listdir(project_dir + 'old_model_fits/' + date)
         modelname = [m for m in datefolder if 'weights' in m][0]
         modelpath = project_dir + 'old_model_fits/{0}/{1}'.format(date, modelname)
+
+    NORM_FACTORS = get_batch_norm_params(species)
 
     model = keras.models.load_model(modelpath)
 
@@ -93,7 +95,7 @@ if __name__ == '__main__':
     x_cnn = []
     y_cnn = []
     phi_cnn = []
-    lx=[];ly=[];tx=[];ty=[];rx=[];ry=[];bx=[];by=[];
+    lx=[];ly=[];tx=[];ty=[];rx=[];ry=[];bx=[];by=[]
 
     # reopen the video with pyav
     container = av.open(video)

--- a/nems_lbhb/pup_py/pupil_fit_script.py
+++ b/nems_lbhb/pup_py/pupil_fit_script.py
@@ -19,6 +19,7 @@ import nems_db
 nems_db_path = nems_db.__path__[0]
 sys.path.append(os.path.join(nems_db_path, 'nems_lbhb/pup_py/'))
 import pupil_settings as ps
+from batch_norm import NORM_FACTORS
 
 import logging
 log = logging.getLogger(__name__)
@@ -125,7 +126,12 @@ if __name__ == '__main__':
             ellipse_parms = model.predict(np.tile(im[np.newaxis, :, :, np.newaxis], [1, 1, 1, 3]))[0]
 
             # rescale parms correctly (based on the resizing and normalizing that was done for the fit)
-            # undo normalization (WIP - CRH 1/30/19)
+            # undo normalization (WIP - CRH 1/30/19 -- update on 6/15/2021, using z-scores per param)
+            for j, (_, v) in enumerate(NORM_FACTORS.items()):
+                # these should be sorted in the same order as y, so no need to use the
+                # dict keys in NORM_FACTORS
+                ellipse_parms[j] = (ellipse_parms[j] * v[2]) #+ v[0]
+            '''
             ellipse_parms /= 100
             ellipse_parms[0] = ellipse_parms[0] * size[0]
             ellipse_parms[1] = ellipse_parms[1] * size[0]
@@ -134,8 +140,9 @@ if __name__ == '__main__':
 
             ellipse_parms[4] = ellipse_parms[4] * np.pi
             ellipse_parms[5:] = ellipse_parms[5:] * size[0] # eyelid keypoints
+            '''
 
-            # undo scaling and save
+            # Finally, undo image scaling and save
             y_cnn.append(ellipse_parms[0] / sf[1])
             x_cnn.append(ellipse_parms[1] / sf[0])
             b_cnn.append(ellipse_parms[2] / sf[1] / 2)

--- a/nems_lbhb/pup_py/pupil_fit_script.py
+++ b/nems_lbhb/pup_py/pupil_fit_script.py
@@ -171,7 +171,7 @@ if __name__ == '__main__':
             'b': np.array(b_cnn),
             'x': np.array(x_cnn),
             'y': np.array(y_cnn),
-            'phi': np.array(phi_cnn)
+            'phi': np.array(phi_cnn),
             'eyelid_left_x': lx,
             'eyelid_left_y': ly,
             'eyelid_top_x': tx,
@@ -179,7 +179,7 @@ if __name__ == '__main__':
             'eyelid_right_x': rx,
             'eyelid_right_y': ry,
             'eyelid_bottom_x': bx,
-            'eyelid_bottom_y': by,
+            'eyelid_bottom_y': by
         },
         'cnn_modelpath': modelpath
     }

--- a/nems_lbhb/pup_py/pupil_settings.py
+++ b/nems_lbhb/pup_py/pupil_settings.py
@@ -5,6 +5,6 @@ import os
 
 ROOT_VIDEO_DIRECTORY = '/auto/data/daq/'
 
-ROOT_DIRECTORY = '/auto/data/nems_db/pup_py/'
+ROOT_DIRECTORY = '/auto/data/nems_db/pup_dev/'
 TRAIN_DATA_PATH = os.path.join(ROOT_DIRECTORY, 'training_data/')
 TMP_SAVE = os.path.join(ROOT_DIRECTORY, 'tmp/')

--- a/nems_lbhb/pup_py/pupil_settings.py
+++ b/nems_lbhb/pup_py/pupil_settings.py
@@ -8,3 +8,4 @@ ROOT_VIDEO_DIRECTORY = '/auto/data/daq/'
 ROOT_DIRECTORY = '/auto/data/nems_db/pup_dev/'
 TRAIN_DATA_PATH = os.path.join(ROOT_DIRECTORY, 'training_data/')
 TMP_SAVE = os.path.join(ROOT_DIRECTORY, 'tmp/')
+TMP_TRAIN = os.path.join(ROOT_DIRECTORY, 'tmp_train/')

--- a/nems_lbhb/pup_py/scratch.py
+++ b/nems_lbhb/pup_py/scratch.py
@@ -1,0 +1,42 @@
+import tkinter
+
+from matplotlib.backends.backend_tkagg import (
+    FigureCanvasTkAgg, NavigationToolbar2Tk)
+# Implement the default Matplotlib key bindings.
+from matplotlib.backend_bases import key_press_handler
+from matplotlib.figure import Figure
+
+import numpy as np
+
+
+root = tkinter.Tk()
+root.wm_title("Embedding in Tk")
+
+fig = Figure(figsize=(5, 4), dpi=100)
+t = np.arange(0, 3, .01)
+fig.add_subplot(111).plot(t, 2 * np.sin(2 * np.pi * t))
+
+canvas = FigureCanvasTkAgg(fig, master=root)  # A tk.DrawingArea.
+canvas.draw()
+
+# pack_toolbar=False will make it easier to use a layout manager later on.
+toolbar = NavigationToolbar2Tk(canvas, root)
+toolbar.update()
+
+
+canvas.mpl_connect(
+    "button_press_event", lambda event: print(f"you pressed {event.xdata}"))
+# key_press_event, event.key
+#canvas.mpl_connect("key_press_event", key_press_handler)
+
+button = tkinter.Button(master=root, text="Quit", command=root.quit)
+
+# Packing order is important. Widgets are processed sequentially and if there
+# is no space left, because the window is too small, they are not displayed.
+# The canvas is rather flexible in its size, so we pack it last which makes
+# sure the UI controls are displayed as long as possible.
+button.pack(side=tkinter.BOTTOM)
+toolbar.pack(side=tkinter.BOTTOM, fill=tkinter.X)
+canvas.get_tk_widget().pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=1)
+
+tkinter.mainloop()

--- a/nems_lbhb/pup_py/scratch.py
+++ b/nems_lbhb/pup_py/scratch.py
@@ -49,4 +49,3 @@ for frame in frames:
 
     with open(f"{filename}", 'wb') as fp:
         pickle.dump(newdata, fp, protocol=pickle.HIGHEST_PROTOCOL)
-

--- a/nems_lbhb/pup_py/scratch.py
+++ b/nems_lbhb/pup_py/scratch.py
@@ -1,42 +1,52 @@
-import tkinter
-
-from matplotlib.backends.backend_tkagg import (
-    FigureCanvasTkAgg, NavigationToolbar2Tk)
-# Implement the default Matplotlib key bindings.
-from matplotlib.backend_bases import key_press_handler
-from matplotlib.figure import Figure
-
+'''
+Helper to manipulate saved training data (if necessary)
+'''
+import os
+import sys
+import nems_db
+nems_db_path = nems_db.__path__[0]
+sys.path.append(os.path.join(nems_db_path, 'nems_lbhb/pup_py/'))
+import nems_lbhb.pup_py.pupil_settings as ps
+import pickle
 import numpy as np
+# realized we need to reorder the key points for the eyelid
+# do this here, rather than "resaving" all the video frames
+frames = os.listdir(ps.TRAIN_DATA_PATH)
+for frame in frames:
+    filename = os.path.join(ps.TRAIN_DATA_PATH, frame)
+    with open(f'{filename}', 'rb') as fp:
+            frame_data = pickle.load(fp)
+            fp.close()
+    edgepoints = [
+        [frame_data['ellipse_zack']['eyelid_left_x'], frame_data['ellipse_zack']['eyelid_left_y']],
+        [frame_data['ellipse_zack']['eyelid_top_x'], frame_data['ellipse_zack']['eyelid_top_y']],
+        [frame_data['ellipse_zack']['eyelid_right_x'], frame_data['ellipse_zack']['eyelid_right_y']],
+        [frame_data['ellipse_zack']['eyelid_bottom_x'], frame_data['ellipse_zack']['eyelid_bottom_y']]
+    ]
+    xlocs = np.array(edgepoints)[:,0]
+    sidx = np.argsort(xlocs)
+    left = sidx[0]
+    right = sidx[3]
+    top = sidx[1]
+    bottom = sidx[2]
+    if edgepoints[top][1]>edgepoints[bottom][1]:
+        pass
+    else:
+        top = sidx[2]
+        bottom = sidx[1]
+    edgepoints = np.array(edgepoints)
+    edgepoints = [edgepoints[left], edgepoints[top], edgepoints[right], edgepoints[bottom]]
 
+    newdata = frame_data.copy()
+    newdata['ellipse_zack']['eyelid_left_x'] = edgepoints[0][0]
+    newdata['ellipse_zack']['eyelid_left_y'] = edgepoints[0][1]
+    newdata['ellipse_zack']['eyelid_top_x'] = edgepoints[1][0]
+    newdata['ellipse_zack']['eyelid_top_y'] = edgepoints[1][1]
+    newdata['ellipse_zack']['eyelid_right_x'] = edgepoints[2][0]
+    newdata['ellipse_zack']['eyelid_right_y'] = edgepoints[2][1]
+    newdata['ellipse_zack']['eyelid_bottom_x'] = edgepoints[3][0]
+    newdata['ellipse_zack']['eyelid_bottom_y'] = edgepoints[3][1]
 
-root = tkinter.Tk()
-root.wm_title("Embedding in Tk")
+    with open(f"{filename}", 'wb') as fp:
+        pickle.dump(newdata, fp, protocol=pickle.HIGHEST_PROTOCOL)
 
-fig = Figure(figsize=(5, 4), dpi=100)
-t = np.arange(0, 3, .01)
-fig.add_subplot(111).plot(t, 2 * np.sin(2 * np.pi * t))
-
-canvas = FigureCanvasTkAgg(fig, master=root)  # A tk.DrawingArea.
-canvas.draw()
-
-# pack_toolbar=False will make it easier to use a layout manager later on.
-toolbar = NavigationToolbar2Tk(canvas, root)
-toolbar.update()
-
-
-canvas.mpl_connect(
-    "button_press_event", lambda event: print(f"you pressed {event.xdata}"))
-# key_press_event, event.key
-#canvas.mpl_connect("key_press_event", key_press_handler)
-
-button = tkinter.Button(master=root, text="Quit", command=root.quit)
-
-# Packing order is important. Widgets are processed sequentially and if there
-# is no space left, because the window is too small, they are not displayed.
-# The canvas is rather flexible in its size, so we pack it last which makes
-# sure the UI controls are displayed as long as possible.
-button.pack(side=tkinter.BOTTOM)
-toolbar.pack(side=tkinter.BOTTOM, fill=tkinter.X)
-canvas.get_tk_widget().pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=1)
-
-tkinter.mainloop()

--- a/nems_lbhb/pup_py/training_script.py
+++ b/nems_lbhb/pup_py/training_script.py
@@ -229,7 +229,7 @@ if __name__ == '__main__':
                 default_name = project_dir + 'default_trained_model/{0}/{1}'.format(old_date, name)
             except:
                 default_name = None
-                print("No old model fits, don't need to purge")
+                log.info("No old model fits, don't need to purge")
 
         # delete the current model from defaults (it is still saved in the
         # parent (probably "old_model_fits") folder under the date it was fit on), along with

--- a/nems_lbhb/pup_py/training_script.py
+++ b/nems_lbhb/pup_py/training_script.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
    
 
     # check for sys arguments to determine how to fit model / where to save results
-    if len(sys.argv) > 1:
+    if 0: #len(sys.argv) > 2:
         # get the animal / animal video key for figuring out which videos to use for training
         animal_name = sys.argv[2]
         video_code = sys.argv[3]
@@ -81,7 +81,7 @@ if __name__ == '__main__':
         path = ps.TRAIN_DATA_PATH  #'/auto/data/nems_db/pup_py/training_data/'
         training_files = os.listdir(path)
         n_training_files = len(training_files)
-        training_epochs = 250  # used to be 500. Make this a user def param?
+        training_epochs = int(sys.argv[2])  # used to be 500. Make this a user def param?
 
         # get current date/time so that we can save the model results in the correct place
         dt = datetime.datetime.now().isoformat()

--- a/nems_lbhb/pup_py/training_script.py
+++ b/nems_lbhb/pup_py/training_script.py
@@ -223,9 +223,13 @@ if __name__ == '__main__':
             except IndexError:
                 default_name = None
         else:
-            old_date = os.listdir(project_dir + 'default_trained_model/')[0]
-            name = os.listdir(project_dir + 'default_trained_model/{0}'.format(old_date))[0]
-            default_name = project_dir + 'default_trained_model/{0}/{1}'.format(old_date, name)
+            try:
+                old_date = os.listdir(project_dir + 'default_trained_model/')[0]
+                name = os.listdir(project_dir + 'default_trained_model/{0}'.format(old_date))[0]
+                default_name = project_dir + 'default_trained_model/{0}/{1}'.format(old_date, name)
+            except:
+                default_name = None
+                print("No old model fits, don't need to purge")
 
         # delete the current model from defaults (it is still saved in the
         # parent (probably "old_model_fits") folder under the date it was fit on), along with

--- a/nems_lbhb/pup_py/training_script.py
+++ b/nems_lbhb/pup_py/training_script.py
@@ -86,9 +86,7 @@ if __name__ == '__main__':
         # get current date/time so that we can save the model results in the correct place
         dt = datetime.datetime.now().isoformat()
         this_model_directory = 'old_model_fits'
-        out = os.system('mkdir {0}{1}/{2}'.format('/auto/data/nems_db/pup_py/', this_model_directory, dt))
-        if out!=0:
-            raise ValueError("Can't make new directory here")
+        out = os.system('mkdir {0}{1}/{2}'.format(ps.ROOT_DIRECTORY, this_model_directory, dt))
 
     load_from_past = False
     # what iteration is this for the current model. Only matters if load_from_past = True

--- a/nems_lbhb/pup_py/training_script.py
+++ b/nems_lbhb/pup_py/training_script.py
@@ -67,11 +67,11 @@ if __name__ == '__main__':
         dt = datetime.datetime.now().isoformat()
         this_model_directory = 'animal_specific_fits/{}'.format(animal_name)
         
-        if os.path.isdir('{0}{1}/'.format('/auto/data/nems_db/pup_py/', this_model_directory)):
-            os.system('mkdir {0}{1}/{2}'.format('/auto/data/nems_db/pup_py/', this_model_directory, dt))
+        if os.path.isdir('{0}{1}/'.format(ps.ROOT_DIRECTORY, this_model_directory)):
+            os.system('mkdir {0}{1}/{2}'.format(ps.ROOT_DIRECTORY, this_model_directory, dt))
         else:
-            os.system('mkdir {0}{1}/'.format('/auto/data/nems_db/pup_py/', this_model_directory))
-            os.system('mkdir {0}{1}/{2}'.format('/auto/data/nems_db/pup_py/', this_model_directory, dt))
+            os.system('mkdir {0}{1}/'.format(ps.ROOT_DIRECTORY, this_model_directory))
+            os.system('mkdir {0}{1}/{2}'.format(ps.ROOT_DIRECTORY, this_model_directory, dt))
 
     else:
         video_code = None
@@ -218,7 +218,7 @@ if __name__ == '__main__':
                 name = os.listdir(project_dir + this_model_directory + '/default_trained_model/{0}'.format(old_date))[0]
                 default_name = project_dir + this_model_directory + '/default_trained_model/{0}/{1}'.format(old_date, name)
             except FileNotFoundError:
-                os.system('mkdir {0}{1}/default_trained_model/'.format('/auto/data/nems_db/pup_py/', this_model_directory))
+                os.system('mkdir {0}{1}/default_trained_model/'.format(ps.ROOT_DIRECTORY, this_model_directory))
                 default_name = None # no default exists yet
             except IndexError:
                 default_name = None

--- a/nems_lbhb/pup_py/training_script.py
+++ b/nems_lbhb/pup_py/training_script.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
     params = {
         'batch_size': 16,
         'image_dim': (224, 224),
-        'n_parms': 5,
+        'n_parms': 13,
         'n_channels': 3,
         'shuffle': True,
         'augment_minibatches': True

--- a/nems_lbhb/pup_py/training_script.py
+++ b/nems_lbhb/pup_py/training_script.py
@@ -86,7 +86,9 @@ if __name__ == '__main__':
         # get current date/time so that we can save the model results in the correct place
         dt = datetime.datetime.now().isoformat()
         this_model_directory = 'old_model_fits'
-        os.system('mkdir {0}{1}/{2}'.format('/auto/data/nems_db/pup_py/', this_model_directory, dt))
+        out = os.system('mkdir {0}{1}/{2}'.format('/auto/data/nems_db/pup_py/', this_model_directory, dt))
+        if out!=0:
+            raise ValueError("Can't make new directory here")
 
     load_from_past = False
     # what iteration is this for the current model. Only matters if load_from_past = True

--- a/nems_lbhb/pup_py/training_script.py
+++ b/nems_lbhb/pup_py/training_script.py
@@ -76,9 +76,10 @@ if __name__ == '__main__':
     else:
         video_code = None
         # project directory
-        project_dir = ps.ROOT_DIRECTORY  #'/auto/data/nems_db/pup_py/'
+        species = sys.argv[1].split('_')[1]
+        project_dir = os.path.join(ps.ROOT_DIRECTORY, species)+ '/'  #'/auto/data/nems_db/pup_py/'
         # data path
-        path = ps.TRAIN_DATA_PATH  #'/auto/data/nems_db/pup_py/training_data/'
+        path = os.path.join(ps.ROOT_DIRECTORY, species, 'training_data/')  #'/auto/data/nems_db/pup_py/training_data/'
         training_files = os.listdir(path)
         n_training_files = len(training_files)
         training_epochs = int(sys.argv[2])  # used to be 500. Make this a user def param?
@@ -86,7 +87,7 @@ if __name__ == '__main__':
         # get current date/time so that we can save the model results in the correct place
         dt = datetime.datetime.now().isoformat()
         this_model_directory = 'old_model_fits'
-        out = os.system('mkdir {0}{1}/{2}'.format(ps.ROOT_DIRECTORY, this_model_directory, dt))
+        out = os.system('mkdir {0}{1}/{2}'.format(project_dir, this_model_directory, dt))
 
     load_from_past = False
     # what iteration is this for the current model. Only matters if load_from_past = True
@@ -96,7 +97,7 @@ if __name__ == '__main__':
     controlled = False
 
     if load_from_past:
-        model_to_load = os.path.join(ps.ROOT_DIRECTORY, 'default_trained_model.hdf5')  
+        model_to_load = os.path.join(project_dir, 'default_trained_model.hdf5')  
     else:
         model_to_load = None
 
@@ -106,7 +107,8 @@ if __name__ == '__main__':
         'n_parms': 13,
         'n_channels': 3,
         'shuffle': True,
-        'augment_minibatches': True
+        'augment_minibatches': True,
+        'species': species
         }
 
     # To make val/train specific to certain videos or not
@@ -218,7 +220,7 @@ if __name__ == '__main__':
                 name = os.listdir(project_dir + this_model_directory + '/default_trained_model/{0}'.format(old_date))[0]
                 default_name = project_dir + this_model_directory + '/default_trained_model/{0}/{1}'.format(old_date, name)
             except FileNotFoundError:
-                os.system('mkdir {0}{1}/default_trained_model/'.format(ps.ROOT_DIRECTORY, this_model_directory))
+                os.system('mkdir {0}{1}/default_trained_model/'.format(project_dir, this_model_directory))
                 default_name = None # no default exists yet
             except IndexError:
                 default_name = None

--- a/nems_lbhb/pup_py/training_script.py
+++ b/nems_lbhb/pup_py/training_script.py
@@ -165,7 +165,9 @@ if __name__ == '__main__':
         # add global average pooling layer
         x = GlobalAveragePooling2D()(x)
         # add output layer
-        predictions = Dense(5, activation='linear')(x)
+        #predictions = Dense(5, activation='linear')(x)
+        # 5 ellipse params + 8 new params for the eyelid keypoints
+        predictions = Dense(13, activation='linear')(x)
 
         model = Model(inputs=base_model.input, outputs=predictions)
 

--- a/nems_lbhb/xform_wrappers.py
+++ b/nems_lbhb/xform_wrappers.py
@@ -37,7 +37,7 @@ log = logging.getLogger(__name__)
 
 
 def _matching_cells(batch=289, siteid=None, alt_cells_available=None,
-                    cell_count=None, best_cells=False):
+                    cell_count=None, best_cells=False, manual_cell_list=None):
 
     if batch==289:
        pmodelname = "ozgf.fs100.ch18-ld-sev_dlog-wc.18x3.g-fir.3x15-lvl.1-dexp.1_init-basic"
@@ -51,7 +51,10 @@ def _matching_cells(batch=289, siteid=None, alt_cells_available=None,
         all_cells = list(single_perf.index)
     log.info("Batch: %d", batch)
     log.info("Per-cell modelname: %s", pmodelname)
-    cellid = [c for c in all_cells if c.split("-")[0]==siteid]
+    if manual_cell_list is None:
+        cellid = [c for c in all_cells if c.split("-")[0]==siteid]
+    else:
+        cellid = manual_cell_list
     this_perf=np.array([single_perf[single_perf.index==c][pmodelname].values[0] for c in cellid])
 
     if cell_count is None:
@@ -182,12 +185,20 @@ def holdout_cells(rec, est, val, exclusions, meta, seed_mod=0, match_to_site=Non
         # pick random subset to exclude
         if match_to_site is not None:
             if exclusions == 0:
-                cell_count = len(nd.get_batch_cells(batch, cellid=match_to_site, as_list=True))
+                if ':' in match_to_site:
+                    cellid_options = {'batch': batch, 'cellid': match_to_site, 'rawid': None}
+                    cells_to_extract, _ = io.parse_cellid(cellid_options)
+                    cell_count = len(cells_to_extract)
+                    manual_cell_list = cells_to_extract
+                else:
+                    cell_count = len(nd.get_batch_cells(batch, cellid=match_to_site, as_list=True))
+                    manual_cell_list = None
             else:
                 cell_count = exclusions
 
             cellid, this_perf, alt_cellid, alt_perf = _matching_cells(
-                batch=batch, siteid=match_to_site, alt_cells_available=rec['resp'].chans, cell_count=cell_count
+                batch=batch, siteid=match_to_site, alt_cells_available=rec['resp'].chans, cell_count=cell_count,
+                manual_cell_list=manual_cell_list
             )
             exclusions = alt_cellid
         else:

--- a/nems_lbhb/xform_wrappers.py
+++ b/nems_lbhb/xform_wrappers.py
@@ -251,9 +251,10 @@ def _get_holdout_recs(rec, cell_set, holdout_set) -> object:
     return rec, holdout_rec
 
 
-def switch_to_heldout_data(holdout_est, holdout_val, holdout_rec, meta, modelspec, trainable_layers=None,
+def switch_to_heldout_data(holdout_est, holdout_val, holdout_rec, meta, modelspec, freeze_layers=None,
                            use_matched_site=False, **context):
     '''Make heldout data the "primary" for final fit. Requires `holdout_cells` during preprocessing.'''
+
     if use_matched_site:
         site = meta['matched_site']
         batch = meta['batch']
@@ -271,10 +272,14 @@ def switch_to_heldout_data(holdout_est, holdout_val, holdout_rec, meta, modelspe
     temp_ms = nems.initializers.from_keywords(meta['modelspecname'], rec=holdout_rec, input_name=context['input_name'],
                                               output_name=context['output_name'])
     temp_ms[0].pop('meta')  # don't overwrite metadata in first module
-    if trainable_layers is None:
-        trainable_layers = list(range(len(temp_ms)))
-    for i in trainable_layers:
-        modelspec[i].update(temp_ms[i])  # overwrite phi, kwargs, etc
+    all_idx = list(range(len(temp_ms)))
+    if freeze_layers is None:
+        freeze_layers = all_idx
+    for i in all_idx:
+        if i not in freeze_layers:
+            modelspec[i].update(temp_ms[i])  # overwrite phi, kwargs, etc
+
+    import pdb; pdb.set_trace()
 
     return {'est': holdout_est, 'val': holdout_val, 'rec': holdout_rec, 'modelspec': modelspec, 'meta': meta}
 

--- a/nems_lbhb/xform_wrappers.py
+++ b/nems_lbhb/xform_wrappers.py
@@ -263,8 +263,6 @@ def _get_holdout_recs(rec, cell_set, holdout_set) -> object:
 def switch_to_heldout_data(meta, modelspec, freeze_layers=None, use_matched_site=False, **context):
     '''Make heldout data the "primary" for final fit. Requires `holdout_cells` during preprocessing.'''
 
-    import pdb; pdb.set_trace()
-
     if use_matched_site:
         site = meta['matched_site']
         batch = meta['batch']

--- a/nems_lbhb/xform_wrappers.py
+++ b/nems_lbhb/xform_wrappers.py
@@ -279,8 +279,6 @@ def switch_to_heldout_data(holdout_est, holdout_val, holdout_rec, meta, modelspe
         if i not in freeze_layers:
             modelspec[i].update(temp_ms[i])  # overwrite phi, kwargs, etc
 
-    import pdb; pdb.set_trace()
-
     return {'est': holdout_est, 'val': holdout_val, 'rec': holdout_rec, 'modelspec': modelspec, 'meta': meta}
 
 


### PR DESCRIPTION
Added additional functionality to pupil analysis. Model now also identifies 4 eyelid key points that can be used to track movement and blinks. For now, default is pointing to pupil training data located on /auto/data/nems_db/pup_dev, instead of the old /auto/data/nems_db/pup_py. Once performance of the method stabizes across new animals etc. consider purging old models in /auto/data/nems_db/pup_py.

Baphy experiment updated to load this information (as well as eyespeed, excluded frames etc.) into a nems signal called pupil_extras whenever data is loaded with pupil=True

Some additional changes included for state-dependent latent variable model fitting. svd / crh