### PR TITLE
Add sortidx to loader

### DIFF
--- a/nems_lbhb/baphy_experiment.py
+++ b/nems_lbhb/baphy_experiment.py
@@ -638,6 +638,7 @@ class BAPHYExperiment:
                         try:
                             mi = unit_names.index(chan_unit_str)
                         except ValueError:
+                            #import pdb; pdb.set_trace()
                             raise RuntimeError(
                                 f'{chan_unit_str} was asked to be loaded, but wasn''t found in the spk.mat file')
                         spikedict[self.cells_to_load[i]] = spiketimes[mi]

--- a/nems_lbhb/baphy_io.py
+++ b/nems_lbhb/baphy_io.py
@@ -1015,7 +1015,9 @@ def baphy_align_time(exptevents, sortinfo, spikefs, finalfs=0, sortidx=0):
 
                     totalunits += 1
                     if chancount <= 8:
-                        unit_names.append("{0}{1}".format(chan_names[c], u+1))
+                        # svd -- avoid letter channel names from now on?
+                        #unit_names.append("{0}{1}".format(chan_names[c], u+1))
+                        unit_names.append("{0:02d}-{1}".format(c+1, u+1))
                     else:
                         unit_names.append("{0:02d}-{1}".format(c+1, u+1))
                     spiketimes.append(unit_spike_events / spikefs)

--- a/nems_lbhb/behavior.py
+++ b/nems_lbhb/behavior.py
@@ -373,7 +373,7 @@ def mark_invalid_trials(exptparams, exptevents, **options):
         # same for single sounds and overall trials
         # TODO add logic to use new structure in exptparams['TrialParams'][1]['CueSeg']
         # to determine cue trials for newer baphy files (after Luke's modifications)
-        nCueTrials = exptparams['TrialObject'][1]['CueTrialCount']
+        nCueTrials = exptparams['TrialObject'][1].get('CueTrialCount',0)
         if nCueTrials > 0:
             cue_hit_trials = events[events.name.str.contains('HIT_TRIAL')]['Trial'][:(nCueTrials+1)].values
             iv = events.Trial.isin(np.arange(1, cue_hit_trials.max()))


### PR DESCRIPTION
This works for my data but we should test it for others. If you send me a list of load commands to try I can test it out. The changes are fairly straightforward but had to be wonky in places because of how things are set up. Most wonky is probably that since baphy_io.baphy_align_time doesn't know what cells you want, it just loads everything in sortidx 1 by default, I added sortidx as an input and it will now get called multiple times if units with sortidx>1 are requested ([line 633 in baphy_experiment.py](https://github.com/LBHB/nems_db/blob/Add_sortidx_to_loader/nems_lbhb/baphy_experiment.py#L633)).